### PR TITLE
Heckefix

### DIFF
--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -619,13 +619,13 @@ end intrinsic;
 
 intrinsic Basis(M::ModFrmHilD, N::RngOrdIdl, k::SeqEnum[RngIntElt]) -> SeqEnum[ModFrmHilDElt], RngIntElt
 { returns a Basis for the space }
-  CB, newforms_dimension := CuspFormBasis(M, k);
+  CB, newforms_dimension := CuspFormBasis(M, N, k);
   H := HeckeCharacterGroup(N);
   //FIXME this is wrong for level not 1!
   print "FIXME this is wrong for level not 1!";
   eta := H ! 1;
   psi := H ! 1;
-  E := EisensteinSeries(M, eta, psi, k);
+  E := EisensteinSeries(M, N, eta, psi, k);
   return [E] cat CB, newforms_dimension;
 end intrinsic;
 

--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -460,47 +460,7 @@ end intrinsic;
 // - Apply Hecke to a Eisensten series, and check that is a multiple
 // - Apply Hecke to a Theta series, and see if we get the whole space
 
-intrinsic HeckeOperator(f::ModFrmHilDElt, nn::RngOrdIdl, chi::GrpHeckeElt) -> ModFrmHilDElt
-  {returns T(n)(f)}
-  M := Parent(f);
-  fcoeffs := Coefficients(f);
-  ideals := Ideals(f);
-  dict := Dictionary(f);
-  ZC := Parent(fcoeffs[1]);
-  k0 := Max(Weight(f));
-  prec:=Precision(M);
-  B:=Basis(M, Level(f),Weight(f));
-  //We work in smaller precision and obtain a function the space of precision Prec/Norm(nn); we then recostruct the rest of the coefficients using the basis B 
-  idealssmallprec:=[ideals[1]];
-  for x:=2 to #ideals do
-    if Norm(ideals[x]) le prec/Norm(nn) then
-      idealssmallprec:= idealssmallprec cat [ideals[x]];
-    end if;
-  end for;
-  coeffssmallprec := [ZC!0 : i in [1..#idealssmallprec]];
-  for i:=1 to #idealssmallprec do
-    c := 0;
-    // loop over divisors
-    // Formula 2.23 in Shimura - The Special Values of the zeta functions associated with Hilbert Modular Forms
-    for aa in Divisors(ideals[i] + nn) do
-      c +:= chi(aa) * Norm(aa)^(k0 - 1) * fcoeffs[ dict[ aa^(-2) * (ideals[i] * nn)]];
-      end for;
-    coeffssmallprec[i] := c;
-    end for;
-   smallprecbasis:=[];
-   for g in B do
-    Append(~smallprecbasis, [Coefficients(g)[i] : i in [1..#idealssmallprec]]);
-   end for;
-   LinComb:=LinearDependence([coeffssmallprec] cat smallprecbasis);
-   if LinComb eq 0 or #Rows(LinComb) ne 1 then
-    return "Error: precision is too small";
-   end if;
-   g:=0*f;
-   for i:=2 to #B+1 do
-    g:=g-LinComb[1][i]*B[i-1];
-   end for;
-  return g;
-end intrinsic;
+
 
 
 intrinsic HeckeOperator(f::ModFrmHilDElt, nn::RngOrdIdl, chi::GrpHeckeElt, B::SeqEnum[ModFrmHilDElt]) -> ModFrmHilDElt
@@ -542,6 +502,13 @@ intrinsic HeckeOperator(f::ModFrmHilDElt, nn::RngOrdIdl, chi::GrpHeckeElt, B::Se
     g:=g-LinComb[1][i]*B[i-1];
    end for;
   return g;
+end intrinsic;
+
+
+intrinsic HeckeOperator(f::ModFrmHilDElt, nn::RngOrdIdl, chi::GrpHeckeElt) -> ModFrmHilDElt
+  {returns T(n)(f)}
+  B:=Basis(M, Level(f),Weight(f));
+  return HeckeOperator(f, nn, chi, B);
 end intrinsic;
 
 // TODO needs testing

--- a/ModFrmHilD/LinearAlgebra.m
+++ b/ModFrmHilD/LinearAlgebra.m
@@ -5,17 +5,7 @@ intrinsic CoefficientsMatrix(list::SeqEnum[ModFrmHilDElt]) -> AlgMatElt
   return Matrix( [ Coefficients(elt) : elt in list] );
 end intrinsic;
 
-//TODO add optional flag to limit the number of coefficients
-intrinsic LinearDependence(list::SeqEnum[ModFrmHilDElt] ) -> SeqEnum[RngIntElt]
-  {finds a small non-trivial integral linear combination between components of v. If none can be found return 0.}
-  M := Matrix( [ Coefficients(elt) : elt in list] );
-  B := Basis(Kernel(M));
-  if #B ne 0 then
-    return Matrix(LLL(Basis(Kernel(M))));
-  else
-    return 0;
-  end if;
-end intrinsic;
+
 
 intrinsic LinearDependence(list::SeqEnum[SeqEnum] ) -> SeqEnum[RngIntElt]
   {finds a small non-trivial integral linear combination between components of v. If none can be found return 0.}
@@ -26,6 +16,12 @@ intrinsic LinearDependence(list::SeqEnum[SeqEnum] ) -> SeqEnum[RngIntElt]
   else
     return 0;
   end if;
+end intrinsic;
+
+//TODO add optional flag to limit the number of coefficients
+intrinsic LinearDependence(list::SeqEnum[ModFrmHilDElt] ) -> SeqEnum[RngIntElt]
+  {finds a small non-trivial integral linear combination between components of v. If none can be found return 0.}
+  return LinearDependence([ Coefficients(elt) : elt in list] );
 end intrinsic;
 
 

--- a/ModFrmHilD/LinearAlgebra.m
+++ b/ModFrmHilD/LinearAlgebra.m
@@ -17,4 +17,16 @@ intrinsic LinearDependence(list::SeqEnum[ModFrmHilDElt] ) -> SeqEnum[RngIntElt]
   end if;
 end intrinsic;
 
+intrinsic LinearDependence(list::SeqEnum[SeqEnum] ) -> SeqEnum[RngIntElt]
+  {finds a small non-trivial integral linear combination between components of v. If none can be found return 0.}
+  M := Matrix( [ elt : elt in list] );
+  B := Basis(Kernel(M));
+  if #B ne 0 then
+    return Matrix(LLL(Basis(Kernel(M))));
+  else
+    return 0;
+  end if;
+end intrinsic;
+
+
 //EchelonBasis


### PR DESCRIPTION
Fixed the Hecke operator, tested it among others on the space over Q(sqrt(5)) of level 1 and weight [6,6]. This space is generated by an Eisenstein series and a newform g with coefficients a(n), and the Hecke operator gives T(n)g=a(n)g

Since the Hecke operator loses precision, we need to reconstruct T(n)f from a basis, so there is a version of the function that takes in a precomputed basis.