### PR TITLE
Heckefix

### DIFF
--- a/tests.m
+++ b/tests.m
@@ -76,3 +76,19 @@ g := ThetaSeries(M, M2);
 assert f*f eq g;
 
 
+//Hecke Operator
+//Basis for level 1 weight [4,4] consists of an eigenstein series and an eigenform
+D := 13;
+F := QuadraticField(D);
+ZF := Integers(F);
+k := [4,4];
+prec := 100;
+M := HMFSpace(F, prec);
+I:=Ideals(M);
+B:=Basis(M, 1*ZF, k);
+f:=B[1];
+g:=B[2];
+assert HeckeOperator(f, 2*ZF : Basis:=B) eq 65*f; // f is an Eisenstein series and is indeed an eigenvalue
+for x:=2 to 7 do
+	assert HeckeOperator(g, I[x] : Basis:=B) eq Coefficients(g)[x]*g; //g is an eigenform
+end for;


### PR DESCRIPTION
Added tests, and now hecke operator automatically returns a form of reduced precision, unless a basis is provided, in which case it returns a form with the same precision. 

The downside is that since each Hecke operator reduces precision, and applying the Hecke operators for different ideals gives forms in all sorts of spaces with different precisions. Since Ben used in his code for canonical embeddings a set lower precision (1000 I think) when looking for basis elements by applying Hecke operators at different ideals, this might not be the best way to go around.