### PR TITLE
Inclusion function fix

### DIFF
--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -643,12 +643,14 @@ end intrinsic;
 ////////// ModFrmHilDElt: M_k(N1) -> M_k(N2) //////////
 
 
-//Todo: True for all ideals or just principal ideals?
+
+
 intrinsic Inclusion(f::ModFrmHilDElt, Mk::ModFrmHilD, dd::RngOrdIdl) -> SeqEnum[ModFrmHilDElt]
   {Takes a form f(z) and produces f(dd*z) in the space Mk}
   coeff_f := Coefficients(f);
   Mk_f := Parent(f);
-  M := Parent(Mk_f);
+  M_f:=Parent(Mk_f);
+  M:=Parent(Mk);
   N1 := Level(Mk_f);
   N2 := Level(Mk);
   require Weight(Mk_f) eq Weight(Mk): "Weight(f) is not equal to Weight(Mk)";
@@ -658,7 +660,7 @@ intrinsic Inclusion(f::ModFrmHilDElt, Mk::ModFrmHilD, dd::RngOrdIdl) -> SeqEnum[
   coeff := AssociativeArray(); 
   for bb in bbs do
     Rep := NarrowClassRepresentative(M,dd*bb);
-    Idealsbb := IdealsByNarrowClassGroup(M)[bb];
+    Idealsbb := IdealsByNarrowClassGroup(M_f)[bb];
     IdealsRep := IdealsByNarrowClassGroup(M)[Rep];
     coeff[Rep] := AssociativeArray();
     for nn in IdealsRep do
@@ -685,6 +687,33 @@ intrinsic Inclusion(f::ModFrmHilDElt, Mk::ModFrmHilD) -> SeqEnum[ModFrmHilDElt]
   end for;
   return IncludedForms;
 end intrinsic;
+
+
+
+intrinsic TraceBoundInclusion(Mk_f, Mk) -> RngIntElt
+  {Gives absolute initial trace precision bound to be able to include f(dd*z) into Mk}
+  M:=Parent(Mk);
+  F:=BaseField(Mk);
+  ZF:=Integers(F);
+  N1 := Level(Mk_f);
+  N2 := Level(Mk);
+  absTraceBound:=Precision(Parent(Mk));
+  for dd in Divisors(N2/N1) do 
+    for nn in AllIdeals(M) do
+      if not nn/dd in AllIdeals(M) then
+        if Norm(nn/dd) in Integers() then
+          nu:=IdealToShintaniRepresentative(M, nn/dd);
+          tnu:=Trace(nu);
+          if tnu gt absTraceBound then
+            absTraceBound:=tnu;
+          end if;
+        end if;
+      end if;
+    end for;
+  end for;
+  return absTraceBound;
+end intrinsic;
+
 
 
 /*

--- a/ModFrmHilD/Multiplication/Shintani.m
+++ b/ModFrmHilD/Multiplication/Shintani.m
@@ -297,11 +297,26 @@ end intrinsic;
 
 // Conversion : Shintani elements < = > Ideals
 // Converts pairs (bb,nu) <-> (bb,n) based on the set of representatives bb for Cl^+(F)
-intrinsic IdealToShintaniRepresentative(M::ModFrmHilDGRng, bb::RngOrdIdl, nn::RngOrdIdl) -> ModFrmHilDElt
+intrinsic IdealToShintaniRepresentative(M::ModFrmHilDGRng, bb::RngOrdIdl, nn::RngOrdIdl) -> RngOrdElt
   {Takes a representative [bb] in Cl^+(F) and an integral ideal n in ZF with [n] = [bb^(-1)] and returns Shintani representative (nu) = n*bb}
   F := BaseField(M);
   mp := NarrowClassGroupMap(M);
   require IsIdentity((nn*bb)@@mp): "The ideals nn and bb must be inverses in CL+(F)";
+  _,gen := IsPrincipal(nn*bb);
+  // This is hardcoded for quadratic Fields.
+  gen := TotallyPostiveAssociate(M,gen);
+  ShintaniGenerator := ReduceShintaniMinimizeTrace(gen);
+  return ShintaniGenerator;
+end intrinsic;
+
+
+// Gives Shintani rep for a given ideal nn
+intrinsic IdealToShintaniRepresentative(M::ModFrmHilDGRng, nn::RngOrdIdl) -> RngOrdElt
+  {Takes a representative [bb] in Cl^+(F) and an integral ideal n in ZF with [n] = [bb^(-1)] and returns Shintani representative (nu) = n*bb}
+  F := BaseField(M);
+  mp := NarrowClassGroupMap(M);
+  bbs := NarrowClassGroupReps(M);
+  bb := [bb : bb in bbs | IsIdentity((nn*bb)@@mp)][1]; // "The ideals nn and bb must be inverses in CL+(F)";
   _,gen := IsPrincipal(nn*bb);
   // This is hardcoded for quadratic Fields.
   gen := TotallyPostiveAssociate(M,gen);


### PR DESCRIPTION
Fixed the inclusion function for the old space. Now the basis function is chatty, telling us with what precision it needs to load the oldspace parts. TODO: optimize the precision so it doesn't load the different parts of the oldspace with unnecessarily high precision