### PR TITLE
Resolution of cusp singularities

### DIFF
--- a/ModFrmHilD/CuspResolution.m
+++ b/ModFrmHilD/CuspResolution.m
@@ -1,0 +1,138 @@
+
+intrinsic IsCoprime(a :: RngQuadFracIdl, b :: RngQuadFracIdl) -> Bool
+{Decide if fractional ideals a and b are coprime}
+    if a eq 0*a or b eq 0*b then return false;
+    end if;
+    primes_a := [f[1] : f in Factorization(a)];
+    primes_b := [f[1] : f in Factorization(b)];
+    for p in primes_a do
+	if p in primes_b then return false;
+	end if;
+    end for;
+    return true;
+end intrinsic;       
+
+intrinsic CuspResolutionM(F :: FldQuad, b :: RngQuadFracIdl, n :: RngQuadIdl,
+			  alpha :: FldQuadElt, beta::FldQuadElt
+			  : flag := -1) ->  RngQuadFracIdl
+						
+{Compute the module M in Van der Geer's notation as a fractional ideal in F.
+See CuspResolutionIntersections for restrictions and definition of flags}
+    ZF := Integers(F);
+    a := alpha*ZF + beta*b^-1;
+    if flag in [-1..2] then 
+	return a^-2 * b^-1 * n;
+	end if;
+end intrinsic;
+
+intrinsic CuspResolutionV(n :: RngQuadIdl : flag := -1) -> RngIntElt
+{Return encoding for the congruence conditions defining V in Van der
+Geer's notation. See CuspResolutionIntersections for definition of flags.
+
+Result semantics:
+0 means V consists of squares of units
+1 means V consists of squares of (units which are 1 mod n)
+2 means V consists of (squares of units) which are 1 mod n}
+    requirerange flag, -1, 2;
+    case flag:
+    when -1:
+	return 1;
+    when 0:
+	return 0;
+    when 1:
+	return 1;
+    when 2:
+	return 2;
+    end case;
+end intrinsic;
+
+intrinsic CuspResolutionMinimalSequence(F :: FldQuad, M :: RngQuadFracIdl) -> SeqEnum[RngIntElt]
+{Compute the periodic part of the HJ continued fraction, as in Van der Geer p.38}
+    require M ne 0*M: "Module M must not be zero";
+    a, b := Explode(Basis(M));
+    head, periodic := HJContinuedFraction(F ! (a/b));
+    return periodic;
+end intrinsic;
+
+intrinsic CuspResolutionMinimalUnit(F :: FldQuad, per :: SeqEnum[RngIntElt]) -> FldQuadElt
+{Compute a generator of U_M+ in Van der Geer's notation}
+    w := HJCyclicProductOfReconstructions(F, periodic);
+    //Check that we indeed have a totally positive unit
+    ZF := Integers(F);
+    assert w in ZF;
+    assert IsUnit(ZF!w) and IsTotallyPositive(ZF!w);
+    return ZF!w;
+end intrinsic;
+
+//This very naive algorithm is still linear in size of final output
+intrinsic UnitMultiplicativeOrderMod(ZF :: RngQuad, p :: RngQuadIdl, eps :: RngQuadElt) -> RngIntElt
+{Compute the multiplicative order of a the unit eps modulo the ideal p}
+    require p ne 0*p: "Ideal p must not be zero";
+    require IsUnit(eps): "eps must be a unit";
+    			 
+    Q := quo<ZF|p>;
+    n := 1;
+    u := eps;
+    while Q!1 ne Q!u do
+        n := n+1; u := eps*u;
+    end while;
+    return n;
+end intrinsic;
+
+intrinsic RepeatSequence(l :: SeqEnum, n :: RngIntElt) -> SeqEnum
+{Output l repeated n times}
+    return &cat[l : x in [1..n]];
+end intrinsic;
+
+intrinsic CuspResolutionIntersections(F :: FldQuad, b :: RngQuadFracIdl, n :: RngQuadIdl,
+				      alpha :: FldQuadElt, beta::FldQuadElt
+				      : flag := -1) -> SeqEnum[RngIntElt]
+							      
+{Compute the cyclic sequence of self-intersection numbers for the
+cycle of P1's appearing in the appearing in the resolution of the cusp
+(alpha:beta) in P^1(F) for the modular group SL(ZF+b) and congruence
+subgroup of level n (prime to b).
+                                                                                                   
+Accepted flags are:
+-1 for full level Gamma(n);
+0  for Gamma_0(n);
+1  for Gamma_1(n);
+2  for Ker(Gamma(1) -> PSL(ZF/n)}
+
+    require IsCoprime(n, b):
+	  "Ideals b (defining the full modular group) and n (defining the level) must be coprime";
+    require alpha*beta ne 0:
+	  "Cusp (alpha:beta) in P^1 cannot have both coordinates zero";
+    requirerange flag, -1, 2;
+
+    ZF := Integers(F);
+    M := CuspResolutionM(F, b, n, alpha, beta, flag);
+    V := CuspResolutionV(n, flag);
+    periodic := CuspResolutionMinimalSequence(F, M);
+    w := CuspResolutionMinimalUnit(F, periodic);
+    issqr, x := IsSquare(w);
+    
+    if issqr then
+	case V:
+	when 0:
+	    m := 1;
+	when 1:
+	    m := UnitMultiplicativeOrderMod(ZF, n, x);
+	when 2:
+	    m := UnitMultiplicativeOrderMod(ZF, n, w);
+	end case;
+    else
+	case V:
+	when 0:
+	    m := 2;
+	when 1:
+	    m := 2*UnitMultiplicativeOrderMod(ZF, n, w);
+	when 2:
+	    m := Lcm(2, UnitMultiplicativeOrderMod(ZF, n, w));
+	end case;
+    end if;
+    L := RepeatSequence(periodic, m);
+    L := [-b: b in L];
+    if #L eq 1 then L := [L[1]+2]; end if;
+    return L;
+end intrinsic;

--- a/ModFrmHilD/CuspResolution.m
+++ b/ModFrmHilD/CuspResolution.m
@@ -139,7 +139,7 @@ Accepted flags are:
 	when 0:
 	    m := 2;
 	when 1:
-	    if IsEven(m) and UnitIsPm1Mod(ZF, n, w^(m/2)) then m := m;
+	    if IsEven(m) and UnitIsPm1Mod(ZF, n, w^(m div 2)) then m := m;
 	    else m := 2*m;
 	    end if;
 	when 2:

--- a/ModFrmHilD/spec
+++ b/ModFrmHilD/spec
@@ -5,6 +5,7 @@
   Formatting.m
   GradedRing.m
   HJ-CFrac.m
+  CuspResolution.m
   Hecke.m
   LinearAlgebra.m
   Space.m

--- a/Tests/cusp_resolution.m
+++ b/Tests/cusp_resolution.m
@@ -1,0 +1,26 @@
+
+//Compute resolution of cusp at infinity following the examples in Van
+//der Geer, pp. 189 and following.
+
+function EqUpToCyclicPermutation(L1, L2)
+    n := #L1;
+    if n ne #L2 then return false; end if;
+    for k := 1 to n do
+	if L1 eq L2 then return true; end if;
+	L1 := L1[2..n] cat [L1[1]];
+    end for;
+    return false;
+end function;
+
+//p.189: Discriminant 5, level Gamma(2)                                                
+F := QuadraticField(5);
+ZF := Integers(F);
+L := CuspResolutionIntersections(F, 1*ZF, 2*ZF, F!1, F!0);
+test := [-3,-3,-3];
+assert EqUpToCyclicPermutation(L, test);
+
+//p.193: Same field, Gamma(3) 
+L := CuspResolutionIntersections(F, 1*ZF, 3*ZF, F!1, F!0);
+test := [-3,-3,-3,-3];
+assert EqUpToCyclicPermutation(L, test);
+

--- a/Tests/cusp_resolution.m
+++ b/Tests/cusp_resolution.m
@@ -1,6 +1,6 @@
 
 //Compute resolution of cusp at infinity following the examples in Van
-//der Geer, pp. 189 and following.
+//der Geer, starting p.189
 
 function EqUpToCyclicPermutation(L1, L2)
     n := #L1;
@@ -24,3 +24,42 @@ L := CuspResolutionIntersections(F, 1*ZF, 3*ZF, F!1, F!0);
 test := [-3,-3,-3,-3];
 assert EqUpToCyclicPermutation(L, test);
 
+//p.195: Discriminant 8, Level Gamma(p7)
+F := QuadraticField(8);
+ZF := Integers(F);
+p7 := Decomposition(ZF, 7)[1][1];
+L := CuspResolutionIntersections(F, 1*ZF, p7, F!1, F!0);
+test := [-2,-4,-2,-4,-2,-4];
+assert EqUpToCyclicPermutation(L, test);
+
+//p.197: Discriminant 13, not quite Gamma(2) but close  
+F := QuadraticField(13);
+ZF := Integers(F);
+p := 2*ZF;
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0: flag:=2);
+test := RepeatSequence([-2,-5,-2], 3); //this is a typo in the book: quadratic number with periodic continued fraction [2,3,2] lies in field of discriminant 21, not 13
+assert EqUpToCyclicPermutation(L, test);
+
+//p.198: Discriminant 17, level Gamma(2)
+F := QuadraticField(17);
+ZF := Integers(F);
+p := 2*ZF;
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0);
+test := [-2,-3,-5,-3,-2];
+assert EqUpToCyclicPermutation(L, test);
+
+//p.199: Discriminant 24, level Gamma(3+sqrt(6))
+F := QuadraticField(24);
+ZF := Integers(F);
+p := (3 + SquareRoot(ZF!6))*ZF;
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0);
+test := RepeatSequence([-2,-2,-2,-4], 2);
+assert EqUpToCyclicPermutation(L, test);
+
+//p.201: Discriminant 40, level Gamma(p2)
+F := QuadraticField(40);
+ZF := Integers(F);
+p := Factorization(2*ZF)[1][1];
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0);
+test := [-2,-3,-4,-3];
+assert EqUpToCyclicPermutation(L, test);


### PR DESCRIPTION
To test the code, we compute some resolutions of the cusp at infinity for level subgroups of the form Gamma(n) in the modular group PSL2(o_k), following examples in Van der Geer's book