### PR TITLE
G(M,V) and explicit cusp change

### DIFF
--- a/Tests/cusp_resolution.m
+++ b/Tests/cusp_resolution.m
@@ -20,40 +20,16 @@ assert alpha1 in ZF and beta1 in ZF;
 assert IsCoprimeFracIdl(alpha1*ZF, n) or IsCoprimeFracIdl(beta1*ZF, n);
 assert IsNormalizedCusp(F, alpha1, beta1, n);
 
-g := CuspChangeMatrix(F, b, F!alpha, F!beta);
-I := alpha*ZF + beta*b^-1;
-
-assert g[1,1] in I^-1;
-assert g[1,2] in I^-1*b^-1;
-assert g[2,1] in I*b;
-assert g[2,2] in I;
-assert g[2,1]*alpha + g[2,2]*beta eq 0;
-
+g := CuspChangeMatrix(F, b, alpha1, beta1);
 I := alpha1*ZF + beta1*b^-1;
-y := alpha1/beta1;
-denom := Gcd(y*ZF, 1*ZF)^-1;
-assert IsCoprimeFracIdl(I, n);
-assert IsCoprimeFracIdl(denom, n);
-
-x := CuspCRT(F, I, n, y);
-assert x in I;
-
-g := NormalizedCuspChangeMatrix(F, b, alpha1, beta1, n);
 assert g[1,1] in I^-1;
 assert g[1,2] in I^-1*b^-1;
 assert g[2,1] in I*b;
 assert g[2,2] in I;
 assert Determinant(g) eq 1;
+assert g[2,1]*alpha1 + g[2,2]*beta1 eq 0;
+assert IsNormalizedCuspChangeMatrix(F, b, n, g);
 
-R<V,M> := PolynomialRing(F, 2);
-stab_elt := Matrix(R, 2, 2, [V, M, 0, 1]);
-conj := g*stab_elt*g^-1;
-
-//conj should be of the form [xm+1, y(v-1)+zm; xm, y(v-1)+zm+1] mod n with x invertible
-assert F!Coefficient(conj[2,1], V, 1) in I*b*n;
-assert F!Coefficient(Coefficient(conj[2,1], V, 0), M, 0) in I*b*n;
-assert F!Coefficient(conj[1,1]-1, V, 1) in I^-1*n;
-assert F!Coefficient(Coefficient(conj[1,1]-1, V, 0), M, 0) in I^-1*n;
 
 //-----------------------------------------------//
 
@@ -74,12 +50,12 @@ end function;
 //p.189: Discriminant 5, level Gamma(2)
 F := QuadraticField(5);
 ZF := Integers(F);
-L := CuspResolutionIntersections(F, 1*ZF, 2*ZF, F!1, F!0);
+L := CuspResolutionIntersections(F, 1*ZF, 2*ZF, F!1, F!0: GammaType:="Gamma");
 test := [-3,-3,-3];
 assert EqUpToCyclicPermutation(L, test);
 
 //p.193: Same field, Gamma(3)
-L := CuspResolutionIntersections(F, 1*ZF, 3*ZF, F!1, F!0);
+L := CuspResolutionIntersections(F, 1*ZF, 3*ZF, F!1, F!0: GammaType:="Gamma");
 test := [-3,-3,-3,-3];
 assert EqUpToCyclicPermutation(L, test);
 
@@ -87,7 +63,7 @@ assert EqUpToCyclicPermutation(L, test);
 F := QuadraticField(8);
 ZF := Integers(F);
 p7 := Decomposition(ZF, 7)[1][1];
-L := CuspResolutionIntersections(F, 1*ZF, p7, F!1, F!0);
+L := CuspResolutionIntersections(F, 1*ZF, p7, F!1, F!0: GammaType:="Gamma");
 test := [-2,-4,-2,-4,-2,-4];
 assert EqUpToCyclicPermutation(L, test);
 
@@ -95,7 +71,7 @@ assert EqUpToCyclicPermutation(L, test);
 F := QuadraticField(13);
 ZF := Integers(F);
 p := 2*ZF;
-L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0: flag:=2);
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0: GammaType:="GammaP");
 test := RepeatSequence([-2,-5,-2], 3); //this is a typo in the book: quadratic number with periodic continued fraction [2,3,2] lies in field of discriminant 21, not 13
 assert EqUpToCyclicPermutation(L, test);
 
@@ -103,7 +79,7 @@ assert EqUpToCyclicPermutation(L, test);
 F := QuadraticField(17);
 ZF := Integers(F);
 p := 2*ZF;
-L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0);
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0: GammaType:="Gamma");
 test := [-2,-3,-5,-3,-2];
 assert EqUpToCyclicPermutation(L, test);
 
@@ -111,7 +87,7 @@ assert EqUpToCyclicPermutation(L, test);
 F := QuadraticField(24);
 ZF := Integers(F);
 p := (3 + SquareRoot(ZF!6))*ZF;
-L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0);
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0: GammaType:="Gamma");
 test := RepeatSequence([-2,-2,-2,-4], 2);
 assert EqUpToCyclicPermutation(L, test);
 
@@ -119,7 +95,57 @@ assert EqUpToCyclicPermutation(L, test);
 F := QuadraticField(40);
 ZF := Integers(F);
 p := Factorization(2*ZF)[1][1];
-L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0);
+L := CuspResolutionIntersections(F, 1*ZF, p, F!1, F!0: GammaType:="Gamma");
 test := [-2,-3,-4,-3];
 assert EqUpToCyclicPermutation(L, test);
+
+//-----------------------------------------------//
+
+printf "Compute resolution of cusps in the case of Gamma1";
+
+//Example with two cusps for Gamma(1)
+K<sqrt5> := QuadraticField(5);
+ZK<phi> := Integers(K);
+p := PrimeIdealsOverPrime(K, 31)[1];
+cusps := Cusps(p, 1*ZK : GammaType := "Gamma1");
+cusps0 := Cusps(p, 1*ZK: GammaType := "Gamma0");
+assert [Eltseq(v): v in cusps] eq [Eltseq(v): v in cusps0];
+
+//Get coordinates of cusps
+alpha1, beta1 := Explode(Coordinates(cusps[1]));
+alpha2, beta2 := Explode(Coordinates(cusps[2]));
+
+//Normalize
+alpha1, beta1 := NormalizeCusp(K, alpha1, beta1, p);
+alpha2, beta2 := NormalizeCusp(K, alpha2, beta2, p);
+
+g1 := CuspChangeMatrix(K, 1*ZK, alpha1, beta1);
+g2 := CuspChangeMatrix(K, 1*ZK, alpha2, beta2);
+
+b := 1*ZK;
+TestCuspChangeMatrix(K, b, p, alpha1, beta1: GammaType:="Gamma0");
+L := CuspResolutionIntersections(K, b, p, alpha1, beta1: GammaType:="Gamma0"); L;
+TestCuspChangeMatrix(K, b, p, alpha2, beta2: GammaType:="Gamma0");
+L := CuspResolutionIntersections(K, b, p, alpha2, beta2: GammaType:="Gamma0"); L;
+TestCuspChangeMatrix(K, b, p, alpha1, beta1: GammaType:="Gamma1");
+L := CuspResolutionIntersections(K, b, p, alpha1, beta1: GammaType:="Gamma1"); L;
+TestCuspChangeMatrix(K, b, p, alpha2, beta2: GammaType:="Gamma1");
+L := CuspResolutionIntersections(K, b, p, alpha2, beta2: GammaType:="Gamma1"); L;
+
+//Try a higher, composite level
+q := PrimeIdealsOverPrime(K, 5)[1];
+n := p^2*q^2;
+for T in ["Gamma0", "Gamma1"] do
+    cusps := Cusps(n, 1*ZK: GammaType := T);
+    for c in cusps do
+	alpha, beta := Explode(Coordinates(c));
+	alpha, beta := NormalizeCusp(K, alpha, beta, n);
+	c, Valuation(alpha,p), Valuation(beta,p),
+	Valuation(beta, p), Valuation(beta, q);
+	TestCuspChangeMatrix(K, b, n, alpha, beta: GammaType:=T);
+	L := CuspResolutionIntersections(K, b, n, alpha, beta: GammaType:=T);
+    end for;
+end for;
+    
+
 return true;

--- a/Tests/cusp_resolution.m
+++ b/Tests/cusp_resolution.m
@@ -138,10 +138,10 @@ n := p^2*q^2;
 for T in ["Gamma0", "Gamma1"] do
     cusps := Cusps(n, 1*ZK: GammaType := T);
     for c in cusps do
+	print "Cusp number", Index(cusps, c);
 	alpha, beta := Explode(Coordinates(c));
 	alpha, beta := NormalizeCusp(K, alpha, beta, n);
-	c, Valuation(alpha,p), Valuation(beta,p),
-	Valuation(beta, p), Valuation(beta, q);
+	//alpha, beta, Valuation(alpha,p), Valuation(beta,p), Valuation(alpha, q), Valuation(beta, q);
 	TestCuspChangeMatrix(K, b, n, alpha, beta: GammaType:=T);
 	L := CuspResolutionIntersections(K, b, n, alpha, beta: GammaType:=T);
     end for;


### PR DESCRIPTION
Computation of G(M,V) for congruence subgroups Gamma0, Gamma1, Gamma: see Overleaf.
Computation of explicit change-of-cusp matrices.
Previous tests in the Gamma case still work, need more tests for Gamma0 and Gamma1.