### PR TITLE
KodairaDimension

### DIFF
--- a/ModFrmHilD/RationalFunctionsTools.m
+++ b/ModFrmHilD/RationalFunctionsTools.m
@@ -13,6 +13,9 @@ intrinsic SubseriesRationalFunction(F::FldFunRatUElt : k := 1) -> FldFunRatUElt
   return Parent(F) ! (Parent(F).1^(v div k)*numLk/denLk);
 end intrinsic;
 
+//BUG: We are claiming that 1/(x-1) has coefficient (x + 1 choose 2)
+//I have my coefficients wrong
+
 //Let F(t) be a rational function, and write F(t) = sum alpha(n) t^n
 // If r1 = r, r2, ..., rk are the roots of the denominator of F, there are polynomials f1(x), ..., fk(x) such that for n large we may write alpha(n) = sum fj(n) rj^n
 // Given r = rj, we return fj(n)
@@ -26,21 +29,23 @@ intrinsic CoefficientComponent(F::FldFunRatUElt : r := 1) -> RngUPolElt
   LG := L ! G;
   v := Valuation(LG);
   R<x> := PolynomialRing(Rationals());
-  MonomialList := [Coefficient(LG, d)*BinomialPolynomial(x + 1 - d, 1 - d) : d in [v..-1]];
+  MonomialList := [Coefficient(LG, d)*BinomialPolynomial(x - d - 1, - d - 1) : d in [v..-1]];
   if MonomialList ne [] then
   return &+MonomialList;
   end if;
   return R!0;
 end intrinsic;
-//UNFINISHED
-//Let F(t) be a rational function, and write F(t) = sum alpha(n) t^n
-// If r1 = r, r2, ..., rk are the roots of the denominator of F, there are polynomials f1(x), ..., fk(x) such that for n large we may write alpha(n) = sum fj(n) rj^n
-//Given F, we return the degree past which the above identity holds
-//intrinsic CoefficientComponentBound(F::FldFunRatUElt) -> RngIntElt
-//{Given F, we return the degree past which the coefficients of the Laurent series of F are of the form sum fj(n) r^n}
-//  PartialFractions := PartialFractionDecomposition(F);
-//  if PartialFractions[1][1] eq q then
-//    return Degree(PartialFractions[1][3]);
-//  end if;
-//  return -1;
-//end intrinsic;
+
+//Let F(t) be a rational function, and write F(t) = sum alpha(n) t^n.
+//Suppose that the coefficients of sum alpha(12 n) t^n are of the form alpha(n) = f(n) for f a fixed polynomial and for all for n large.
+//We return the degree of f
+//Returns -1 if f = 0
+//This should be the Kodaira dimension, in a particular context, if memory serves
+intrinsic KodairaDimension(F::FldFunRatUElt : k := 12, r:= 1) -> RngIntElt
+  {Given a rational function (and an index k and a scalar r), returns the degree of the polynomial coefficient of r^n in the Taylor series expansion of the series with knth coefficients extracted}
+  SubseriesF := SubseriesRationalFunction(F : k := k);
+  if SubseriesF eq 0 then
+  return -1;
+  end if;
+  return Degree(CoefficientComponent(SubseriesF : r := r));
+end intrinsic;


### PR DESCRIPTION
Fixed a sign error, so that CoefficientComponent runs correctly.

Let F(t) be a rational function representing a Hilbert modular form (or a quotient thereof). Write F(t) = sum_{n >> n0} a(n) t^n. If a(12n) = p(n) for some polynomial p and all n sufficiently large, KodairaDimension(F) returns the degree of p. I believe that in particular contexts, this is precisely the Kodaira dimension of the Hilbert modular variety. But this function may need to be renamed and incorporated into larger aspects of the code.