### PR TITLE
Split constant term of Eisenstein series, weight 1 code improvement

### DIFF
--- a/ModFrmHilD/Creation/EisensteinSeries.m
+++ b/ModFrmHilD/Creation/EisensteinSeries.m
@@ -53,7 +53,158 @@ intrinsic EisensteinSeries(
   return E;
 end intrinsic;
 
+intrinsic EisensteinConstantCoefficient(
+    M::ModFrmHilDGRng,
+    Weight::SeqEnum[RngIntElt],
+    eta::GrpHeckeElt,
+    psi::GrpHeckeElt
+    ) -> Tup
+  {return an associative array with constant coefficients indexed by bb}
+    
+  // We are following the notation in Section 2.2 of Dasgupta, Darmon, Pollack - Hilbert Modular Forms and the Gross-Stark Conjecture
+  aa := Modulus(eta); // aa := Conductor(eta);
+  bb := Modulus(psi); // bb := Conductor(psi);
+  require #SequenceToSet(Weight) eq 1: "We only support EisensteinSeries with parallel weight";
+  k := Weight[1];
 
+  //Set the coefficient field to be the common field for eta and psi.
+  lcm := LCM(Order(eta), Order(psi));
+  L<z> := CyclotomicField(lcm);
+  etainv := eta^-1;
+  psiinv := psi^-1;
+  SetTargetRing(~eta, z);
+  SetTargetRing(~psi, z);
+  SetTargetRing(~etainv, z);
+  SetTargetRing(~psiinv, z);
+
+  // deal with L-values
+  if IsOne(aa) then // aa = 1
+    prim := AssociatedPrimitiveCharacter(psi*eta^(-1));
+    SetTargetRing(~prim, z);
+    c0aa := LValue_Recognized(M, k, prim);
+  else
+    c0aa := 0;
+  end if;
+  // k = 1 and bb == 1
+  if k eq 1 and IsOne(bb) then
+    prim := AssociatedPrimitiveCharacter(eta*psi^(-1));
+    SetTargetRing(~prim, z);
+    c0bb := LValue_Recognized(M, k, prim);
+  else
+    c0bb := 0;
+  end if;
+
+  constant_term := AssociativeArray();
+  n := Degree(BaseField(M));
+
+  // deal with L-values
+  if IsOne(aa) then // aa = 1
+    prim := AssociatedPrimitiveCharacter(psi*eta^(-1));
+    SetTargetRing(~prim, z);
+    c0aa := L!LValue_Recognized(M, k, prim);
+  else
+    c0aa := 0;
+  end if;
+  // k = 1 and bb == 1
+  if k eq 1 and IsOne(bb) then
+    prim := AssociatedPrimitiveCharacter(eta*psi^(-1));
+    SetTargetRing(~prim, z);
+    c0bb := L!LValue_Recognized(M, k, prim);
+  else
+    c0bb := 0;
+  end if;
+
+  constant_term := AssociativeArray();
+  n := Degree(BaseField(M));
+  bbs := NarrowClassGroupReps(M);
+  for bb in bbs do
+    constant_term[bb] := AssociativeArray();
+    // zero term for bb, equation (49) and (50)
+    // For them [nn] = \lambda, while we have [nn][bb']=[(1)]
+    // Thus we may take tt_lambda = 1/bb'$
+    bbp := NarrowClassGroupRepsToIdealDual(M)[bb];
+    tt_lambda := bbp^-1;
+    constant_term[bb] := 2^(-n)*( etainv(tt_lambda)*c0aa +  psiinv(tt_lambda)*c0bb );
+  end for;
+
+
+  // Normalize coefficients
+  bb1 := bbs[1];
+  c0inv := (not (constant_term[bb1] in [0,1])) select (1/constant_term[bb1]) else 1;
+  for bb->c in constant_term do
+    constant_term[bb] *:= c0inv;
+  end for;
+  assert constant_term[bb1] in [0,1];
+
+    return constant_term;
+end intrinsic;
+
+//intrinsic EisensteinNonConstantCoefficient(
+//    M::ModFrmHilDGRng,
+//    Weight::SeqEnum[RngIntElt],
+//    eta::GrpHeckeElt,
+//    psi::GrpHeckeElt,
+//    ideals::SeqEnum[RngOrdIdl]
+//    ) -> Tup
+//  {return an associative array with a_nn with nn in ideals indexed by bb}
+//    
+//  // We are following the notation in Section 2.2 of Dasgupta, Darmon, Pollack - Hilbert Modular Forms and the Gross-Stark Conjecture
+//  aa := Modulus(eta); // aa := Conductor(eta);
+//  bb := Modulus(psi); // bb := Conductor(psi);
+//  require #SequenceToSet(Weight) eq 1: "We only support EisensteinSeries with parallel weight";
+//  k := Weight[1];
+//
+//  //Set the coefficient field to be the common field for eta and psi.
+//  lcm := LCM(Order(eta), Order(psi));
+//  L<z> := CyclotomicField(lcm);
+//  etainv := eta^-1;
+//  psiinv := psi^-1;
+//  SetTargetRing(~eta, z);
+//  SetTargetRing(~psi, z);
+//  SetTargetRing(~etainv, z);
+//  SetTargetRing(~psiinv, z);
+//
+//
+//  coeffs := AssociativeArray();
+//  for nn in ideals do
+//    if not IsZero(nn) then
+//      coeffs[nn] := c0inv * &+[eta(nn/rr) * psi(rr) * Norm(rr)^(k - 1) : rr in Divisors(nn)];
+//    end if;
+//  end for;
+//
+//    return coeffs;
+//end intrinsic;
+
+//intrinsic EisensteinCoefficientsFact(
+//    M::ModFrmHilDGRng,
+//    Weight::SeqEnum[RngIntElt],
+//    eta::GrpHeckeElt,
+//    psi::GrpHeckeElt,
+//    ideals::SeqEnum[RngOrdIdl]
+//  ) -> Tup
+//  {Factored code for Eisenstein Coefficients}
+//    lcm := LCM(Order(eta), Order(psi));
+//    L<z> := CyclotomicField(lcm);
+//    
+//    constant_term := EisensteinConstantCoefficient(M, Weight,eta,psi);
+//    coeffs := EisensteinNonConstantCoefficients(M, Weight,eta,psi,ideals);
+//
+//  // reduce field of definition
+//  if Degree(L) eq 1 then
+//    Lsub := Rationals();
+//  else
+//    Lsub := sub<L | [elt : elt in (Values(coeffs) cat Values(constant_term))]>;
+//  end if;
+//  if L ne Lsub then
+//    for nn->c in coeffs do
+//      coeffs[nn] := Lsub!c;
+//    end for;
+//    for bb->c in constant_term do
+//      constant_term[bb] := Lsub!c;
+//    end for;
+//  end if;
+//    return <constant_term, coeffs>;
+//end intrinsic;
 
 intrinsic EisensteinCoefficients(
   M::ModFrmHilDGRng,

--- a/ModFrmHilD/Creation/Weight1.m
+++ b/ModFrmHilD/Creation/Weight1.m
@@ -98,11 +98,240 @@ intrinsic Weight1CuspBasis(
     end for;
 
 
-  print "Need to verify that the precision is large enough to compute the space larger space\n";
+  vprintf HilbertModularForms: "Need to verify that the precision is large enough to compute the space larger space\n";
 
   B4 := Basis(HMFSpace(M, N, [4,4]));
   assert #LinearDependence(B4) eq 0;
   end if;
 
   return Vnew;
+end intrinsic;
+
+// Computes a basis of cuspidal weight 1 forms.
+intrinsic Weight1CuspBasisNew(
+  Mk::ModFrmHilD
+  :
+  pp := false,
+  prove := true
+  ) -> SeqEnum[ModFrmHilDElt]
+  {Compute the basis of cuspidal parallel weight 1 forms using the Hecke stability method.
+    The optional parameter pp specifies which Hecke operator T_pp to use;
+    otherwise use smallest pp coprime to the level.
+    The optional paramter prove should be true or false. If true, we verify that the candidates
+    for the weight one forms obtained from the Hecke stability method are indeed holomorphic.
+  }
+  M := Parent(Mk);
+  k := Weight(Mk);
+  assert k[1] eq 1 and k[2] eq 1;
+  N := Level(Mk);
+  chi := Character(Mk);
+  chiinv := chi^(-1);
+  ZF := Integers(M);
+
+  assert IsGamma1EisensteinWeight(chi, k);
+
+  //Load an Eisenstein series of weight [1,1], character chi.
+  vprintf HilbertModularForms: "Computing an Eisenstein series of weight [1, 1] and character %o\n", chiinv;
+  M1 := HMFSpace(M, N, [1,1], chiinv);
+  AdmChars := EisensteinAdmissibleCharacterPairs(M1);
+  require #AdmChars gt 0: "No Eisenstein series of correct character";
+    
+    ok := false;
+
+    for pair in AdmChars do
+        myarray := EisensteinConstantCoefficient(M, [1,1], pair[1], pair[2]); 
+        if not (&*[myarray[key] : key in Keys(myarray)] eq 0) then
+            ok := true;
+            mypair := pair;
+            break;
+        end if;
+    end for;
+    
+    if ok then
+        vprint HilbertModularForms: "There is a non-vanishing Eisenstein series of weight 1.";
+      pair := mypair;
+      E1 := EisensteinSeries(M1, pair[1], pair[2]);
+    
+        
+      //Load space of Cusp forms of weight [2,2] and level N.
+      vprintf HilbertModularForms: "Computing basis of cusp forms of weight [2,2] and level \n %o\n", N;
+      M2 := HMFSpace(M, N, [2,2]);
+      B2 := CuspFormBasis(M2);
+      vprintf HilbertModularForms: "Size of basis is %o.\n", #B2;
+
+      //Choosing the prime pp, skipping primes dividing level just to be safe. Probably not needed?
+      if pp cmpeq false then
+        for p in PrimesUpTo(100) do
+          if Norm(N) mod p eq 0 then
+            continue;
+          end if;
+        pp := Factorization(p*ZF)[1][1];
+        break;
+        end for;
+      end if;
+      vprintf HilbertModularForms: "Using Hecke operator at prime \n %o \n of norm %o.\n", pp, Norm(pp);
+
+      //Now we start the big computation.
+      vprintf HilbertModularForms: "Starting the big computation...\n";
+      cont := true;
+
+      V := [];
+      for f in B2 do
+        Append(~V, f/E1);
+      end for;
+
+      Vprev := V;
+      dimprev := #V;
+
+      while cont do
+        vprintf HilbertModularForms:  "Current dim = %o\n", dimprev;
+        TpVprev := [];
+        for g in Vprev do
+          Append(~TpVprev, HeckeOperator(g, pp));
+        end for;
+
+        lindep := LinearDependence(Vprev cat TpVprev);
+        dimnew := #lindep;
+        vprintf HilbertModularForms: "New dim = %o\n", dimnew;
+
+        if dimprev eq dimnew then
+          cont := false;
+        end if;
+
+        Vnew := [];
+        for vec in lindep do
+          f := &+[vec[i]*Vprev[i] : i in [1 .. #Vprev]];
+          Append(~Vnew, f);
+        end for;
+
+        assert #Vnew eq dimnew;
+
+        Vprev := Vnew;
+        dimprev := #Vprev;
+      end while;
+
+      if prove then
+        vprintf HilbertModularForms: "Checking that forms are holomorphic by squaring\n";
+        
+        if Order(chi) eq 1 then
+            B2chi2 := B2;
+        else
+            M2chi2 := HMFSpace(M, N, [2,2], chi^2);
+            B2chi2 := CuspFormBasis(M2chi2);
+        end if;
+
+        for f in Vnew do
+          V2 := Append(B2chi2, f^2);
+          assert #LinearDependence(V2) gt 0;
+        end for;
+
+
+      print "Need to verify that the precision is large enough to compute the space larger space\n";
+
+      B4 := Basis(HMFSpace(M, N, [4,4]));
+      assert #LinearDependence(B4) eq 0;
+      end if;
+
+      return Vnew;
+    else
+        vprint HilbertModularForms: "There is no non-vanishing Eisenstein series of weight 1, we go to weight 3.";
+        
+        vprintf HilbertModularForms: "Computing an Eisenstein series of weight [3, 3] and character %o\n", chiinv;
+        M3 := HMFSpace(M, N, [3,3], chiinv);
+        AdmChars := EisensteinAdmissibleCharacterPairs(M3);
+        require #AdmChars gt 0: "No Eisenstein series of correct character";
+    
+        ok := false;
+
+        for pair in AdmChars do
+            myarray := EisensteinConstantCoefficient(M, [3,3], pair[1], pair[2]); 
+            if not (&*[myarray[key] : key in Keys(myarray)] eq 0) then
+                ok := true;
+                mypair := pair;
+                break;
+            end if;
+        end for;
+        
+        require ok: "We would need to go to weight 5... Not implemented yet.";
+
+        pair := mypair;
+        E3 := EisensteinSeries(M3, pair[1], pair[2]);
+        
+        //Load space of Cusp forms of weight [4, 4] and level N.
+        vprintf HilbertModularForms: "Computing basis of cusp forms of weight [4,4] and level \n %o\n", N;
+        M4 := HMFSpace(M, N, [4,4]);
+        B4 := CuspFormBasis(M4);
+        vprintf HilbertModularForms: "Size of basis is %o.\n", #B4;
+
+        //Choosing the prime pp, skipping primes dividing level just to be safe. Probably not needed?
+        if pp cmpeq false then
+        for p in PrimesUpTo(100) do
+          if Norm(N) mod p eq 0 then
+            continue;
+          end if;
+        pp := Factorization(p*ZF)[1][1];
+        break;
+        end for;
+        end if;
+        vprintf HilbertModularForms: "Using Hecke operator at prime \n %o \n of norm %o.\n", pp, Norm(pp);
+
+          //Now we start the big computation.
+          vprintf HilbertModularForms: "Starting the big computation...\n";
+          cont := true;
+
+          V := [];
+          for f in B4 do
+            Append(~V, f/E3);
+          end for;
+
+          Vprev := V;
+          dimprev := #V;
+
+          while cont do
+            vprintf HilbertModularForms:  "Current dim = %o\n", dimprev;
+            TpVprev := [];
+            for g in Vprev do
+              Append(~TpVprev, HeckeOperator(g, pp));
+            end for;
+
+            lindep := LinearDependence(Vprev cat TpVprev);
+            dimnew := #lindep;
+            vprintf HilbertModularForms: "New dim = %o\n", dimnew;
+
+            if dimprev eq dimnew then
+              cont := false;
+            end if;
+
+            Vnew := [];
+            for vec in lindep do
+              f := &+[vec[i]*Vprev[i] : i in [1 .. #Vprev]];
+              Append(~Vnew, f);
+            end for;
+
+            assert #Vnew eq dimnew;
+
+            Vprev := Vnew;
+            dimprev := #Vprev;
+          end while;
+
+          if prove then
+            vprintf HilbertModularForms: "Checking that forms are holomorphic by squaring\n";
+
+            M2chi2 := HMFSpace(M, N, [2,2], chi^2);
+            B2chi2 := CuspFormBasis(M2chi2);
+
+            for f in Vnew do
+              V2 := Append(B2chi2, f^2);
+              assert #LinearDependence(V2) gt 0;
+            end for;
+
+
+          print "Need to verify that the precision is large enough to compute the space larger space\n";
+
+          B4 := Basis(HMFSpace(M, N, [8,8]));
+          assert #LinearDependence(B4) eq 0;
+          end if;
+
+          return Vnew;
+    end if;
 end intrinsic;


### PR DESCRIPTION
- I didn't factor the Eisenstein series code in the end, because higher Eisenstein coefficients are normalized using the constant term, so it seems a little complicated. For now, I split out a function to compute the constant term.
- New functionality of weight 1 code: if the weight 1Eisenstein series is cuspidal on some component, use a weight 3 Eisenstein series instead.