### PR TITLE
fix iteration over associative arrays

### DIFF
--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -490,12 +490,12 @@ end intrinsic;
 
 intrinsic IsZero(f::ModFrmHilDEltComp) -> BoolElt
   {check if form is identically zero}
-  return IsZero([c : c in Coefficients(f)]);
+  return IsZero([c : k->c in Coefficients(f)]);
 end intrinsic;
 
 intrinsic IsZero(f::ModFrmHilDElt) -> BoolElt
   {check if form is identically zero}
-  return IsZero([f_bb : f_bb in Components(f)]);
+  return IsZero([f_bb : k->f_bb in Components(f)]);
 end intrinsic;
 
 intrinsic HMFIdentity(Mk::ModFrmHilD, bb::RngOrdIdl) -> ModFrmHilDEltComp


### PR DESCRIPTION
[value: value in AssociativeArray] doesn't work for earlier versions of Magma; instead, iteration of values is done using
[value: k-> value in AssociativeArray]. Temporary fix