### PR TITLE
Linear algebra for forms with irrational coefficients

### DIFF
--- a/ModFrmHilD/LinearAlgebra.m
+++ b/ModFrmHilD/LinearAlgebra.m
@@ -58,12 +58,9 @@ intrinsic CoefficientsMatrix(list::SeqEnum[ModFrmHilDElt] : IdealClasses:=false,
   end if;
 
   nus := [ShintaniRepsUpToTrace(M, bb, prec) : bb in bbs];
-  mat := Matrix([
-    &cat[
-      &cat[Eltseq(Coefficients(Components(f)[bb])[nu]) : nu in nus[i]]
-      : i->bb in bbs]
-    : f in list]);
-  assert Ncols(mat) eq &+[#elt : elt in nus]*Degree(CoefficientRing(list[1]));
+
+  mat := Matrix([&cat[[Coefficients(Components(f)[bb])[nu] : nu in nus[i]] : i->bb in bbs] : f in list]);
+  assert Ncols(mat) eq &+[#elt : elt in nus];
   assert Nrows(mat) eq #list;
   return mat, nus, bbs;
 end intrinsic;
@@ -75,9 +72,21 @@ intrinsic ShortLinearDependence(M::Mtrx) -> SeqEnum[RngIntElt]
     If none can be found return 0.
   }
   // in case M is defined over the rationals
-  M := ChangeRing(Denominator(M)*M, Integers());
+  if CanChangeRing(M, Rationals()) then
+    M := ChangeRing(Denominator(M)*M, Integers());
+  end if;
+  
   B := Basis(Kernel(M));
-  if #B ne 0 then return [Eltseq(i) : i in Rows(Matrix(LLL(B)))]; else return []; end if;
+
+  if #B eq 0 then
+    return [];
+  elif CanChangeRing(M, Rationals()) then
+    kernel_basis_vectors := Rows(Matrix(LLL(B)));
+  else 
+    kernel_basis_vectors := B;
+  end if;
+  // return a SeqEnum of SeqEnums instead of a SeqEnum of vectors
+  return [Eltseq(v) : v in kernel_basis_vectors];
 end intrinsic;
 
 


### PR DESCRIPTION
The existing `LinearDependence` function, given a list of `ModFrmHilDElt` objects, computes their coefficient matrix and then returns its kernel. However, the coefficient matrix function is a matrix over $\mathbb{Q}$, formed by choosing a $\mathbb{Q}$ basis for the base field $F$ and expressing each coefficient as $[F:\mathbb{Q}]$ columns of the coefficient matrix. This means that when the kernel of this matrix is taken, we can only detect $\mathbb{Q}$-linear dependence. 

For example, if I had two forms over $F = \mathbb{Q}(\sqrt{5})$ with one coefficient each, and those coefficients were $1$ and $1+\sqrt{5}$ respectively, and I chose $\{1, \sqrt{5}\}$ for my $\mathbb{Q}$-basis of $F$, then the coefficient matrix would be $\begin{pmatrix} 1 & 0 \\ 1 & 1 \end{pmatrix}$, which has trivial kernel. even though the forms are dependent over $F$.

We now let the coefficient matrix be defined over the compositum of the base fields of the HMFs.