### PR TITLE
Fix nebentypus-weight compatibility check

### DIFF
--- a/Tests/k-chi-compatibility.m
+++ b/Tests/k-chi-compatibility.m
@@ -1,0 +1,59 @@
+// tests the function IsCompatibleWeight in ModFrmHilD/Space.m
+
+F := QuadraticField(5);
+// the signs of the units are
+//
+//      inf_1  inf_2
+// U.1  -1     -1
+// U.2   1     -1
+ZF := Integers(F);
+N := 1*ZF;
+H := HeckeCharacterGroup(N, [1,2]);
+
+// the trivial character is compatible with any 
+// weight whose components are all even
+
+assert IsCompatibleWeight(H.0, [2,2]);
+assert not IsCompatibleWeight(H.0, [2,3]);
+assert IsCompatibleWeight(H.0, [2,4]);
+
+// nontrivial level
+N := 23*ZF;
+H := HeckeCharacterGroup(N, [1,2]); // H = Z/22
+
+assert IsCompatibleWeight(H.0, [2,2]);
+assert not IsCompatibleWeight(H.0, [2,3]);
+
+// the character H.1 sends 
+//       (23) | psi_0
+// U.1    1   |   1                  
+// U.2   -1   |  -1
+
+assert IsCompatibleWeight(H.1, [5,7]);
+assert not IsCompatibleWeight(H.1, [9,4]);
+
+// multiple finite bad primes
+N := 21*ZF;
+H := HeckeCharacterGroup(N, [1,2]); // H = Z/2 x Z/24
+                                    
+// the character H.2 sends 
+//       (3)   (7) | psi_0
+// U.1    1     1  |   1                  
+// U.2   -1     1  |  -1
+//
+assert IsCompatibleWeight(H.2, [3,3]);
+assert not IsCompatibleWeight(H.2, [2,2]);
+
+// order dependent,
+// components have values outside 1 and -1
+N := 11*ZF;
+H := HeckeCharacterGroup(N, [1,2]); // H = Z/10 x Z/2
+// the character H.1 sends 
+//        pp          pp'        | psi_0
+// U.1     1          -1         |  -1                  
+// U.2     z    -(z^3+z^2+z+1)   |   1
+// where z = zeta_5.
+
+assert IsCompatibleWeight(H.1, [3,2]);
+assert not IsCompatibleWeight(H.1, [2,3]);
+


### PR DESCRIPTION
Let $K$ be the base field and $m = m_{0}m_{\infty}$ be the modulus. Magma thinks of (finite order) Hecke characters as ray class characters. Let $\psi$ denote the Dirichlet restriction of $\chi$, i.e.\ the character on the ray residue ring $K^{m}/K^{m,1}$ defined by $\psi(x) := \chi((x))$. Because $K^{m}/K^{m,1} \cong \{\pm 1\}^{|m_{\infty}|} \times (O_K/m)^{\times}$, we can decompose $\psi$ as $\psi_\infty \cdot \psi_0$ on the two factors. The transformation law for HMFs with nebentypus only cares about $\psi_0$. This makes sense to me because, analogous to modular forms, the nebentypus in level N and component $b$ ought to be a character of $\Gamma_0(b, N)/\Gamma_1(b,N) \cong (O_K/N)^{\times}$. The condition $\psi_0(\epsilon) = (\text{sign}(\epsilon))^k$ for every $\epsilon \in O_K^{\times}$ arises from considering the action of the matrix $[\epsilon, 0], [0, \epsilon]$ on an HMF.

Currently, the `IsCompatibleWeight`  function checks the condition that $\psi(\epsilon) = (\text{sign}(\epsilon))^k$ instead of the correct condition with $\psi_0$, and this commit fixes that.
~