### PR TITLE
Improvements to Hecke stability

### DIFF
--- a/ModFrmHilD/Basis.m
+++ b/ModFrmHilD/Basis.m
@@ -82,7 +82,7 @@ intrinsic CuspFormBasis(
       end if;
       require CuspDimension(Mk) eq dim : Sprintf("CuspDimension(Mk) = %o != %o = #Mk`CuspFormBasis", CuspDimension(Mk), #Mk`CuspFormBasis);
     else
-      Mk`CuspFormBasis := Weight1CuspBasis(Mk);
+      Mk`CuspFormBasis := HeckeStabilityCuspBasis(Mk);
     end if;
   end if;
   return SubBasis(Mk`CuspFormBasis, IdealClassesSupport, Symmetric);

--- a/ModFrmHilD/Creation/EisensteinSeries.m
+++ b/ModFrmHilD/Creation/EisensteinSeries.m
@@ -123,7 +123,7 @@ intrinsic EisensteinConstantCoefficient(
     // For them [nn] = \lambda, while we have [nn][bb']=[(1)]
     // Thus we may take tt_lambda = 1/bb'$
     bbp := NarrowClassGroupRepsToIdealDual(M)[bb];
-    tt_lambda := bbp^-1;
+    tt_lambda := bbp;
     constant_term[bb] := 2^(-n)*( etainv(tt_lambda)*c0aa +  psiinv(tt_lambda)*c0bb );
   end for;
 

--- a/ModFrmHilD/Creation/EisensteinSeries.m
+++ b/ModFrmHilD/Creation/EisensteinSeries.m
@@ -81,26 +81,6 @@ intrinsic EisensteinConstantCoefficient(
   if IsOne(aa) then // aa = 1
     prim := AssociatedPrimitiveCharacter(psi*eta^(-1));
     SetTargetRing(~prim, z);
-    c0aa := LValue_Recognized(M, k, prim);
-  else
-    c0aa := 0;
-  end if;
-  // k = 1 and bb == 1
-  if k eq 1 and IsOne(bb) then
-    prim := AssociatedPrimitiveCharacter(eta*psi^(-1));
-    SetTargetRing(~prim, z);
-    c0bb := LValue_Recognized(M, k, prim);
-  else
-    c0bb := 0;
-  end if;
-
-  constant_term := AssociativeArray();
-  n := Degree(BaseField(M));
-
-  // deal with L-values
-  if IsOne(aa) then // aa = 1
-    prim := AssociatedPrimitiveCharacter(psi*eta^(-1));
-    SetTargetRing(~prim, z);
     c0aa := L!LValue_Recognized(M, k, prim);
   else
     c0aa := 0;

--- a/ModFrmHilD/Creation/EisensteinSeries.m
+++ b/ModFrmHilD/Creation/EisensteinSeries.m
@@ -74,8 +74,6 @@ intrinsic EisensteinConstantCoefficient(
   psiinv := psi^-1;
   SetTargetRing(~eta, z);
   SetTargetRing(~psi, z);
-  SetTargetRing(~etainv, z);
-  SetTargetRing(~psiinv, z);
 
   // deal with L-values
   if IsOne(aa) then // aa = 1
@@ -100,9 +98,12 @@ intrinsic EisensteinConstantCoefficient(
   for bb in bbs do
     constant_term[bb] := AssociativeArray();
     // zero term for bb, equation (49) and (50)
+    // their tt_lambda is our bbp
     bbp := NarrowClassGroupRepsToIdealDual(M)[bb];
-    tt_lambda := bbp;
-    constant_term[bb] := 2^(-n)*( etainv(tt_lambda)*c0aa +  psiinv(tt_lambda)*c0bb );
+    etainv_of_bbp := (IsDisjoint(Support(bbp), Support(Conductor(eta)))) select eta(bbp)^-1 else 0;
+    psiinv_of_bbp := (IsDisjoint(Support(bbp), Support(Conductor(psi)))) select psi(bbp)^-1 else 0;
+
+    constant_term[bb] := 2^(-n)*(etainv_of_bbp * c0aa + psiinv_of_bbp * c0bb );
   end for;
 
 

--- a/ModFrmHilD/Creation/EisensteinSeries.m
+++ b/ModFrmHilD/Creation/EisensteinSeries.m
@@ -100,8 +100,6 @@ intrinsic EisensteinConstantCoefficient(
   for bb in bbs do
     constant_term[bb] := AssociativeArray();
     // zero term for bb, equation (49) and (50)
-    // For them [nn] = \lambda, while we have [nn][bb']=[(1)]
-    // Thus we may take tt_lambda = 1/bb'$
     bbp := NarrowClassGroupRepsToIdealDual(M)[bb];
     tt_lambda := bbp;
     constant_term[bb] := 2^(-n)*( etainv(tt_lambda)*c0aa +  psiinv(tt_lambda)*c0bb );
@@ -116,75 +114,8 @@ intrinsic EisensteinConstantCoefficient(
   end for;
   assert constant_term[bb1] in [0,1];
 
-    return constant_term;
+  return constant_term, c0inv;
 end intrinsic;
-
-//intrinsic EisensteinNonConstantCoefficient(
-//    M::ModFrmHilDGRng,
-//    Weight::SeqEnum[RngIntElt],
-//    eta::GrpHeckeElt,
-//    psi::GrpHeckeElt,
-//    ideals::SeqEnum[RngOrdIdl]
-//    ) -> Tup
-//  {return an associative array with a_nn with nn in ideals indexed by bb}
-//    
-//  // We are following the notation in Section 2.2 of Dasgupta, Darmon, Pollack - Hilbert Modular Forms and the Gross-Stark Conjecture
-//  aa := Modulus(eta); // aa := Conductor(eta);
-//  bb := Modulus(psi); // bb := Conductor(psi);
-//  require #SequenceToSet(Weight) eq 1: "We only support EisensteinSeries with parallel weight";
-//  k := Weight[1];
-//
-//  //Set the coefficient field to be the common field for eta and psi.
-//  lcm := LCM(Order(eta), Order(psi));
-//  L<z> := CyclotomicField(lcm);
-//  etainv := eta^-1;
-//  psiinv := psi^-1;
-//  SetTargetRing(~eta, z);
-//  SetTargetRing(~psi, z);
-//  SetTargetRing(~etainv, z);
-//  SetTargetRing(~psiinv, z);
-//
-//
-//  coeffs := AssociativeArray();
-//  for nn in ideals do
-//    if not IsZero(nn) then
-//      coeffs[nn] := c0inv * &+[eta(nn/rr) * psi(rr) * Norm(rr)^(k - 1) : rr in Divisors(nn)];
-//    end if;
-//  end for;
-//
-//    return coeffs;
-//end intrinsic;
-
-//intrinsic EisensteinCoefficientsFact(
-//    M::ModFrmHilDGRng,
-//    Weight::SeqEnum[RngIntElt],
-//    eta::GrpHeckeElt,
-//    psi::GrpHeckeElt,
-//    ideals::SeqEnum[RngOrdIdl]
-//  ) -> Tup
-//  {Factored code for Eisenstein Coefficients}
-//    lcm := LCM(Order(eta), Order(psi));
-//    L<z> := CyclotomicField(lcm);
-//    
-//    constant_term := EisensteinConstantCoefficient(M, Weight,eta,psi);
-//    coeffs := EisensteinNonConstantCoefficients(M, Weight,eta,psi,ideals);
-//
-//  // reduce field of definition
-//  if Degree(L) eq 1 then
-//    Lsub := Rationals();
-//  else
-//    Lsub := sub<L | [elt : elt in (Values(coeffs) cat Values(constant_term))]>;
-//  end if;
-//  if L ne Lsub then
-//    for nn->c in coeffs do
-//      coeffs[nn] := Lsub!c;
-//    end for;
-//    for bb->c in constant_term do
-//      constant_term[bb] := Lsub!c;
-//    end for;
-//  end if;
-//    return <constant_term, coeffs>;
-//end intrinsic;
 
 intrinsic EisensteinCoefficients(
   M::ModFrmHilDGRng,
@@ -205,72 +136,10 @@ intrinsic EisensteinCoefficients(
   //Set the coefficient field to be the common field for eta and psi.
   lcm := LCM(Order(eta), Order(psi));
   L<z> := CyclotomicField(lcm);
-  etainv := eta^-1;
-  psiinv := psi^-1;
   SetTargetRing(~eta, z);
   SetTargetRing(~psi, z);
-  SetTargetRing(~etainv, z);
-  SetTargetRing(~psiinv, z);
 
-  // deal with L-values
-  if IsOne(aa) then // aa = 1
-    prim := AssociatedPrimitiveCharacter(psi*eta^(-1));
-    SetTargetRing(~prim, z);
-    c0aa := LValue_Recognized(M, k, prim);
-  else
-    c0aa := 0;
-  end if;
-  // k = 1 and bb == 1
-  if k eq 1 and IsOne(bb) then
-    prim := AssociatedPrimitiveCharacter(eta*psi^(-1));
-    SetTargetRing(~prim, z);
-    c0bb := LValue_Recognized(M, k, prim);
-  else
-    c0bb := 0;
-  end if;
-
-  constant_term := AssociativeArray();
-  n := Degree(BaseField(M));
-
-  // deal with L-values
-  if IsOne(aa) then // aa = 1
-    prim := AssociatedPrimitiveCharacter(psi*eta^(-1));
-    SetTargetRing(~prim, z);
-    c0aa := L!LValue_Recognized(M, k, prim);
-  else
-    c0aa := 0;
-  end if;
-  // k = 1 and bb == 1
-  if k eq 1 and IsOne(bb) then
-    prim := AssociatedPrimitiveCharacter(eta*psi^(-1));
-    SetTargetRing(~prim, z);
-    c0bb := L!LValue_Recognized(M, k, prim);
-  else
-    c0bb := 0;
-  end if;
-
-  constant_term := AssociativeArray();
-  n := Degree(BaseField(M));
-  bbs := NarrowClassGroupReps(M);
-  for bb in bbs do
-    constant_term[bb] := AssociativeArray();
-    // zero term for bb, equation (49) and (50)
-    // For them [nn] = \lambda, while we have [nn][bb']=[(1)]
-    // Thus we may take tt_lambda = 1/bb'$
-    bbp := NarrowClassGroupRepsToIdealDual(M)[bb];
-    tt_lambda := bbp^-1;
-    constant_term[bb] := 2^(-n)*( etainv(tt_lambda)*c0aa +  psiinv(tt_lambda)*c0bb );
-  end for;
-
-
-  // Normalize coefficients
-  bb1 := bbs[1];
-  c0inv := (not (constant_term[bb1] in [0,1])) select (1/constant_term[bb1]) else 1;
-  for bb->c in constant_term do
-    constant_term[bb] *:= c0inv;
-  end for;
-  assert constant_term[bb1] in [0,1];
-
+  constant_term, c0inv := EisensteinConstantCoefficient(M, Weight, eta, psi);
 
   coeffs := AssociativeArray();
   for nn in ideals do
@@ -296,8 +165,6 @@ intrinsic EisensteinCoefficients(
 
   return <constant_term, coeffs>;
 end intrinsic;
-
-
 
 //Toolbox function to use in the Eisenstein series function--gives us an L value
 intrinsic LValue_Recognized(M::ModFrmHilDGRng, k::RngIntElt, psi::GrpHeckeElt) -> FldNumElt

--- a/ModFrmHilD/Creation/Weight1.m
+++ b/ModFrmHilD/Creation/Weight1.m
@@ -102,7 +102,7 @@ intrinsic HeckeStabilityCuspBasis(
     // this Eisenstein series should be nonzero at the cusp at infinity in
     // every component. Thus, we should be able to divide by it
     // and obtain something with nebentypus character chi. 
-    myarray := EisensteinConstantCoefficient(M, par_wt_1, chi_prim^-1, triv_char);
+    myarray, _ := EisensteinConstantCoefficient(M, par_wt_1, chi_prim^-1, triv_char);
     require &*[myarray[key] : key in Keys(myarray)] ne 0 : "The Eisenstein series you've chosen is 0 at some cusps at infinity";
     
     // TODO abhijitm there's something annoying going on here

--- a/ModFrmHilD/Creation/Weight1.m
+++ b/ModFrmHilD/Creation/Weight1.m
@@ -9,10 +9,7 @@ intrinsic HeckeStableSubspace(
     // compute the kernel of Tp
     // we include the kernel in our final output
     // because it is also Hecke stable
-    TpV := [];
-    for f in V do
-      Append(~TpV, HeckeOperator(f, pp));
-    end for;
+    TpV := [HeckeOperator(f, pp) : f in V];
     lindep := LinearDependence(TpV);
     Tp_kernel := [&+[vec[i]*V[i] : i in [1 .. #V]] : vec in lindep];
 
@@ -24,11 +21,7 @@ intrinsic HeckeStableSubspace(
     
     for _ in [1 .. #V] do
         vprintf HilbertModularForms:  "Current dim = %o\n", dimprev;
-        TpVprev := [];
-        for g in Vprev do
-            Append(~TpVprev, HeckeOperator(g, pp));
-        end for;
-        
+        TpVprev := [HeckeOperator(g, pp) : g in Vprev];
         lindep := LinearDependence(Vprev cat TpVprev);
         dimnew := #lindep;
         
@@ -127,11 +120,8 @@ intrinsic HeckeStabilityCuspBasis(
     vprintf HilbertModularForms: "Dividing by the Eisenstein series\n";
     
     //Our initial candidate for our desired space.
-    V := [];
-    for f in Bkl do
-        Append(~V, f/Eis);
-    end for;
-
+    V := [f/Eis : f in Bkl];
+   
     // We want to choose the prime pp of smallest norm among
     // the primes not dividing N
     bound := 20;
@@ -242,11 +232,7 @@ intrinsic Eigenbasis(M::ModFrmHilD, basis::SeqEnum[ModFrmHilDElt] : P := 60) -> 
   F := MGRng`BaseField;
   ZF := Integers(F);
   dd := Different(ZF);
-  hecke_matrices := [];
-
-  for pp in PrimesUpTo(P, F) do
-    Append(~hecke_matrices, HeckeMatrix(basis, pp));
-  end for;
+  hecke_matrices := [HeckeMatrix(basis, pp) : pp in PrimesUpTo(P, F)];
 
   // B stores a matrix such that B * M * B^-1 is
   // diagonal for every Hecke matrix M. 

--- a/ModFrmHilD/Creation/Weight1.m
+++ b/ModFrmHilD/Creation/Weight1.m
@@ -93,16 +93,18 @@ intrinsic HeckeStabilityCuspBasis(
     ZF := Integers(M);
     n := Degree(F);
 
-    par_wt_1 := [1 : _ in [1 .. n]];
-    MEis := HMFSpace(M, N, par_wt_1, chi^-1);
-    triv_char := HeckeCharacterGroup(1*ZF, [1,2]).0;
-    MEis := HMFSpace(M, N, par_wt_1, chi^-1);
+    par_wt_k := func<k | [k : _ in [1 .. n]]>;
+    eis_k := (N ne 1*ZF) select 1 else 3;
+    eis_wt := par_wt_k(eis_k);
+    MEis := HMFSpace(M, N, eis_wt, chi^-1);
+
     triv_char := HeckeCharacterGroup(1*ZF, [1 .. n]).0;
+
     // By Proposition 2.1 in DDP11 (https://annals.math.princeton.edu/wp-content/uploads/annals-v174-n1-p12-s.pdf)
     // this Eisenstein series should be nonzero at the cusp at infinity in
     // every component. Thus, we should be able to divide by it
     // and obtain something with nebentypus character chi. 
-    myarray, _ := EisensteinConstantCoefficient(M, par_wt_1, chi_prim^-1, triv_char);
+    myarray, _ := EisensteinConstantCoefficient(M, eis_wt, chi_prim^-1, triv_char);
     require &*[myarray[key] : key in Keys(myarray)] ne 0 : "The Eisenstein series you've chosen is 0 at some cusps at infinity";
     
     // TODO abhijitm there's something annoying going on here
@@ -114,10 +116,10 @@ intrinsic HeckeStabilityCuspBasis(
     //
     // We take the primitive character 
     Eis := EisensteinSeries(MEis, chi_prim^-1, triv_char);
-        
-    //Load space of Cusp forms of weight [k1 + 1, ..., kn + 1], level N, and trivial character
-    vprintf HilbertModularForms: "Computing basis of cusp forms of weight %o, level %o\n", [k[i] + 1 : i in [1 .. n]], N;
-    Mkl := HMFSpace(M, N, [k[i] + 1 : i in [1 .. n]]);
+
+    //Load space of Cusp forms of weight [k1 + eis_k, ..., kn + eis_k], level N, and trivial character
+    vprintf HilbertModularForms: "Computing basis of cusp forms of weight %o, level %o\n", [k[i] + eis_k : i in [1 .. n]], N;
+    Mkl := HMFSpace(M, N, [k[i] + eis_k : i in [1 .. n]]);
     Bkl := CuspFormBasis(Mkl);
     vprintf HilbertModularForms: "Size of basis is %o.\n", #Bkl;
     

--- a/ModFrmHilD/Creation/Weight1.m
+++ b/ModFrmHilD/Creation/Weight1.m
@@ -37,14 +37,20 @@ intrinsic HeckeStableSubspace(
         for vec in lindep do
             f := &+[vec[i]*Vprev[i] : i in [1 .. #Vprev]];
             M := CoefficientsMatrix([f]); 
-            d := Denominator(M);
-            M := Matrix(Integers(),d*M);
-            gcd_M := GCD(Eltseq(M));
-            // If the generalization of Schaeffer's theorem to HMFs is true,
-            // then this can never happen
-            require gcd_M ne 0 : "We didn't think this could happen -- you may have found\
-                    an interesting example! Please email TODO.";
-            Append(~Vnew, f/gcd_M);
+            // TODO abhijitm should do something like this in general too,
+            // but clearing denominators seems annoying over number fields.
+            if Parent(M[1][1]) eq Rationals() then
+              d := Denominator(M);
+              M := Matrix(Integers(),d*M);
+              gcd_M := GCD(Eltseq(M));
+              // If the generalization of Schaeffer's theorem to HMFs is true,
+              // then this can never happen
+              require gcd_M ne 0 : "We didn't think this could happen -- you may have found\
+                      an interesting example! Please email TODO.";
+              Append(~Vnew, f/gcd_M);
+            else 
+              Append(~Vnew, f);
+            end if;
         end for;
 
         // If the iterative intersection process has stabilized,

--- a/ModFrmHilD/Creation/Weight1.m
+++ b/ModFrmHilD/Creation/Weight1.m
@@ -201,18 +201,6 @@ intrinsic HeckeStabilityCuspBasis(
     return [];
 end intrinsic;
 
-// Computes a basis of cuspidal weight 1 forms.
-intrinsic Weight1CuspBasis(
-  Mk::ModFrmHilD
-  :
-  prove := true
-  ) -> SeqEnum[ModFrmHilDElt]
-  {Compute the basis of cuspidal parallel weight 1 forms using the Hecke stability method.
-   - The optional parameter prove is true or false. If true, we verify that we had enough precision to check the equality of the potentially meromorphic form with a holomorphic one.
-  }
-  return HeckeStabilityCuspBasis(Mk : prove := prove);
-end intrinsic;
-
 ///////////// Eigenbasis computation ////////////////
 
 // This code computes an eigenbasis for a Hecke-stable space 

--- a/Tests/hecke_stab_33chi.m
+++ b/Tests/hecke_stab_33chi.m
@@ -1,0 +1,53 @@
+// Given a [1,1] Eisenstein series E of (nonquadratic) nebentypus chi
+// and cusp spaces S_22 and S_44 of weights [2,2] and [4,4]
+// respectively, checks that S_22*f is the Hecke stable subspace of
+// S_44/f
+
+PREC := 17;
+
+function test(F, N, chi)
+  // F - number field
+  // N - level
+  // chi - nebentypus, of modulus N
+
+  ZF := Integers(F);
+  M := GradedRingOfHMFs(F, PREC);
+  triv_char := HeckeCharacterGroup(1*ZF, [1,2]).0;
+
+  M11chi := HMFSpace(M, N, [1,1], chi);
+  E := EisensteinSeries(M11chi, chi, triv_char);
+
+  M11chiinv := HMFSpace(M, N, [1,1], chi^-1);
+  Einv := EisensteinSeries(M11chiinv, chi^-1, triv_char);
+
+  M22 := HMFSpace(M, N, [2,2]);
+  B22 := CuspFormBasis(M22);
+
+  M44 := HMFSpace(M, N, [4,4]);
+  B44 := CuspFormBasis(M44);
+
+  W := [f * E : f in B22];
+  V := [f / Einv : f in B44];
+
+  // TODO abhijitm should rework the weight 1 code
+  // into code that computes spaces with nontrivial nebentypus,
+  // should be fairly easy. This is a stopgap I guess.
+  pp := 3*ZF;
+  U := HeckeStableSubspace(V, pp);
+
+  // want all of W to be in the Hecke stable subspace of V
+  assert #LinearDependence(U cat W) eq #W;
+end function;
+
+
+F := QuadraticField(5);
+
+N := 14*ZF;
+H := HeckeCharacterGroup(N, [1,2]);
+chi := H.1; // order 6
+test(F, N, chi);
+
+N := 5*Factorization(5*ZF)[1][1]; 
+H := HeckeCharacterGroup(N, [1,2]);
+chi := H.1; // order 5
+test(F, N, chi);

--- a/Tests/hecke_stab_kernel.m
+++ b/Tests/hecke_stab_kernel.m
@@ -1,0 +1,31 @@
+F := QuadraticField(5);
+ZF := Integers(F);
+prec := 13;
+pp := 2*ZF;
+M := GradedRingOfHMFs(F, prec);
+triv_char := HeckeCharacterGroup(1*ZF, [1,2]).0;
+
+N := 7*ZF; 
+H := HeckeCharacterGroup(N, [1,2]);
+
+chi := H.1^3;
+
+M11chi := HMFSpace(M, N, [1,1], chi);
+eis := EisensteinSeries(M11chi, chi, triv_char);
+
+M_22 := HMFSpace(M, N, [2,2]);
+M_44 := HMFSpace(M, N, [4,4]);
+
+B_44 := CuspFormBasis(M_44);
+
+B_22 := CuspFormBasis(M_22);
+
+// The space of [2,2] forms of this level 
+// is one-dimensional, spanned
+// by a form whose coefficient corresponding
+// to the ideal (2) is 0. Therefore, this form
+// lies in the kernel of the action of Tpp on
+// on V. 
+V := [f/eis^2 : f in B_44];
+W := HeckeStableSubspace(V, pp);
+assert #LinearDependence(W cat B_22) eq #B_22;

--- a/Tests/squaring_wt1.m
+++ b/Tests/squaring_wt1.m
@@ -7,6 +7,6 @@ N:= 23*ZF;
 H := HeckeCharacterGroup(N, [1,2]);
 chi := (H.1^11);
 Mchi := HMFSpace(M, N, [1,1], chi);
-B := Weight1CuspBasis(Mchi : prove := false);
+B := HeckeStabilityCuspBasis(Mchi : prove := false);
 f := B[1];
 g := f^2;

--- a/Tests/wt1lvl23.m
+++ b/Tests/wt1lvl23.m
@@ -7,7 +7,7 @@ N:= 23*ZF;
 H := HeckeCharacterGroup(N, [1,2]);
 chi := H.1^11; // (H.1^11); // aka 11 mod 22
 M1chi := HMFSpace(M, N, [1,1], chi);
-Space := Weight1CuspBasis(M1chi : prove := false);
+Space := HeckeStabilityCuspBasis(M1chi : prove := false);
 f := Space[1];
 f := f/Coefficient(f, 1*ZF);
 
@@ -353,6 +353,6 @@ N:= 23*ZF;
 H := HeckeCharacterGroup(N, [1,2]);
 chi := H.1^11*H.2*H.3; 
 M1chi := HMFSpace(M, N, [1,1], chi);
-Space := Weight1CuspBasis(M1chi : prove := false);
+Space := HeckeStabilityCuspBasis(M1chi : prove := false);
 assert #Space eq 4;
 


### PR DESCRIPTION
- Simplify the Hecke stability algorithm by picking an Eisenstein series "directly" rather than by searching for one. 
- Pick out the kernel of the chosen Hecke operator in advance before proceeding with the Hecke intersection method, since anything in the kernel is automatically Hecke stable and (at least conjecturally) is a holomorphic form.
- Test the use of `HeckeStableSubspace` for computing spaces of HMFs of nontrivial nebentypus in higher weight