### PR TITLE
unit characters for nonparallel weights

### DIFF
--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -885,7 +885,7 @@ intrinsic '*'(f::ModFrmHilDEltComp, g::ModFrmHilDEltComp) -> ModFrmHilDEltComp
       smu1, epsilon1 := Explode(xpair); // <s(mu1), epsilon1>
       smu2, epsilon2 := Explode(ypair); // <s(mu2), epsilon2>
       if evaluate_bool then
-        c +:= StrongMultiply(F, [* Evaluate(char_f, epsilon1), coeffs_f[smu1], Evaluate(char_g, epsilon2), coeffs_g[smu2] *]);
+        c +:= StrongMultiply(F, [* Evaluate(char_f, epsilon1^(-1)), coeffs_f[smu1], Evaluate(char_g, epsilon2^(-1)), coeffs_g[smu2] *]);
       else
         c +:= StrongMultiply(F, [* coeffs_f[smu1], coeffs_g[smu2] *]);
       end if;
@@ -916,7 +916,7 @@ intrinsic '/'(f::ModFrmHilDEltComp, g::ModFrmHilDEltComp) -> ModFrmHilDEltComp
   require ComponentIdeal(f) eq ComponentIdeal(g): "we only support division with the same component";
 
   LandingSpace := Parent(f)/Parent(g);
-  char_f := UnitCharacter(f);
+  char_g := UnitCharacter(g);
   char_h := UnitCharacters(LandingSpace)[ComponentIdeal(f)];
 
   coeffs_f := Coefficients(f);
@@ -945,7 +945,7 @@ intrinsic '/'(f::ModFrmHilDEltComp, g::ModFrmHilDEltComp) -> ModFrmHilDEltComp
   prec_g := Precision(g);
   prec := Minimum(prec_f, prec_g);
 
-  evaluate_bool := not IsOne(char_f) or not IsOne(char_h);
+  evaluate_bool := not IsOne(char_g) or not IsOne(char_h);
 
   for nu in ShintaniRepsUpToTrace(GradedRing(f), ComponentIdeal(f), prec)  do
     sum := F!0; // will record sum_{mu + mu' = nu, mu != 0} a(g)_mu a(h)_mu'
@@ -962,7 +962,7 @@ intrinsic '/'(f::ModFrmHilDEltComp, g::ModFrmHilDEltComp) -> ModFrmHilDEltComp
         count +:= 1;
       else
         if evaluate_bool then
-          sum +:= StrongMultiply(F, [* Evaluate(char_f, epsilon1), coeffs_g[smu1], Evaluate(char_h, epsilon2), F!coeffs_h[smu2] *]);
+          sum +:= StrongMultiply(F, [* Evaluate(char_g, epsilon1^(-1)), coeffs_g[smu1], Evaluate(char_h, epsilon2^(-1)), F!coeffs_h[smu2] *]);
         else
           sum +:= StrongMultiply(F, [* coeffs_g[smu1],  F!coeffs_h[smu2] *]);
         end if;

--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -501,8 +501,7 @@ intrinsic HMFIdentity(Mk::ModFrmHilD, bb::RngOrdIdl) -> ModFrmHilDEltComp
   X := HeckeCharacterGroup(N, [1..Degree(BaseField(M))]);
   chi := X!1;
   k := [0 : i in Weight(Mk)];
-  uc := UnitCharacters(Mk);
-  M0 := HMFSpace(M, N, k, chi: unitcharacters:=uc);
+  M0 := HMFSpace(M, N, k, chi);
   coeffs := AssociativeArray();
   for nu in ShintaniReps(M)[bb] do
     if IsZero(nu) then

--- a/ModFrmHilD/FldExt.m
+++ b/ModFrmHilD/FldExt.m
@@ -439,3 +439,64 @@ intrinsic AutsReppingEmbeddingsOfF(F::FldNum, k::SeqEnum[RngIntElt] : Precision 
   end for;
   return [aut_dict[i] : i in [1 .. n]];
 end intrinsic;
+
+intrinsic EltToShiftedHalfWeight(x::FldElt, k::SeqEnum[RngIntElt]) -> FldElt
+  {
+    inputs: 
+      x: A totally positive element of a number field F. 
+         If k is nonparitious, we require x to be a totally
+         positive unit. 
+         // TODO abhijitm feels weird, will come back to it later,
+         // but the point is that we won't actually run this in the
+         // eigenvalue -> Fourier coefficient computation for
+         // nonparitious (and maybe eventually all) weights,
+         // so it only gets used to compute unit characters. 
+      k: A weight
+    returns:
+      We want to compute the element
+      y := \prod_i x_i^((k_0-k_i)/2)
+      where x_i is the image of eps under the ith real embedding of F,
+      k = (k_1, ..., k_n) is the weight, and k_0 = max_i(k_i). 
+
+      This quantity appears in the computation of the unit character 
+      as well as the computation of Fourier coefficients from Hecke eigenvalues.
+
+      The element y will lie in the UnitCharField(F,k). 
+  }
+
+  assert IsTotallyPositive(x);
+  if not IsParitious(k) then
+    assert Norm(x) eq 1;
+  end if;
+
+  F := Parent(x);
+  K := UnitCharField(F, k);
+  k0 := Max(k);
+
+  if IsParallel(k) then
+    return K!1;
+  end if;
+
+  auts := AutsReppingEmbeddingsOfF(F, k);
+  if IsParitious(k) then
+    // paritious nonparallel weight
+    return &*[auts[i](K!x)^(ExactQuotient(k0 - k[i], 2)) : i in [1 .. #auts]];
+  else
+    // nonparitious weight
+    v_0 := DistinguishedPlace(K);
+    y := &*[auts[i](Sqrt(K!x))^(k0 - k[i]) : i in [1 .. #auts]];
+    return PositiveInPlace(y, v_0);
+  end if;
+end intrinsic;
+
+
+intrinsic PositiveInPlace(nu::FldNumElt, v::PlcNumElt) -> FldNumElt
+  {
+    input: 
+      nu: An element of a number field F
+      v: A place of F
+    return:
+      nu if v(nu) > 0 and -nu otherwise.
+  }
+  return (Evaluate(nu, v) gt 0) select nu else -1*nu;
+end intrinsic;

--- a/ModFrmHilD/Space.m
+++ b/ModFrmHilD/Space.m
@@ -232,21 +232,21 @@ end intrinsic;
 intrinsic HMFSpace(M::ModFrmHilDGRng, N::RngOrdIdl, k::SeqEnum[RngIntElt], chi::GrpHeckeElt : unitcharacters:=false) -> ModFrmHilD
   {}
   spaces := Spaces(M);
+  F := BaseField(M);
   if unitcharacters cmpeq false then
     unitcharacters := AssociativeArray();
     for bb in NarrowClassGroupReps(M) do
-      unitcharacters[bb] := TrivialUnitCharacter(BaseField(M));
+      unitcharacters[bb] := WeightUnitCharacter(F, k);
     end for;
   end if;
 
   uc_values := &cat[ValuesOnGens(unitcharacters[bb]) : bb in NarrowClassGroupReps(M)];
-
   if IsDefined(spaces, N) then
     if IsDefined(spaces[N], <k, chi, uc_values>) then
       return spaces[N][<k, chi, uc_values>];
     end if;
   else
-    M`Spaces[N] := AssociativeArray();
+    M`Spaces[N] := AssociativeArray(PowerStructure(Tup));
   end if;
   Mk := ModFrmHilDInitialize();
   Mk`Parent := M;

--- a/ModFrmHilD/UnitChar.m
+++ b/ModFrmHilD/UnitChar.m
@@ -88,6 +88,44 @@ intrinsic TrivialUnitCharacter(F::FldAlg) -> GrpCharUnitTotElt
  return UnitCharacter(F, [1: i in [1..#Generators(TotallyPositiveUnits(F))]]);
 end intrinsic;
 
+intrinsic WeightUnitCharacter(F::FldAlg, k::SeqEnum[RngIntElt]) -> GrpCharUnitTotElt
+  {
+    input:
+      F: A (totally real) number field
+      k: A sequence of (positive) integers
+    returns:
+      The unit character sending eps to 
+      \prod_i eps_i^(k_i/2),
+      where eps_i is the image of eps under the ith real embedding of F
+      and k is the weight associated to Mk. 
+
+      This is the "standard" unit character. It is trivial for parallel weight
+      because (\prod_i eps_i)^k = N(eps)^k = 1, but for nonparallel weight
+      it will be nontrivial. 
+  }
+
+  // if the weight is parallel then the unit character is trivial
+  if IsParallel(k) then
+    return TrivialUnitCharacter(F);
+  end if;
+
+  n := Degree(F);
+  places := RealPlaces(F);
+  
+  vals := [];
+  for eps in TotallyPositiveUnitsGenerators(F) do
+    // EltToShiftedHalfWeight computes 
+    // \prod_i eps_i^((k_0-k_i)/2),
+    // where k_0 = Max(k). However, 
+    // prod_i eps_i^(k_0/2) = N(eps)^(k_0/2) = 1
+    // since we take positive square roots, so 
+    // to get the product we want we just need 
+    // to invert the output. 
+    Append(~vals, EltToShiftedHalfWeight(F!eps, k)^-1);
+  end for;
+  return UnitCharacter(F, vals);
+end intrinsic;
+
 intrinsic Print(omega::GrpCharUnitTotElt, level::MonStgElt)
   {}
 

--- a/Tests/auts_representing_embeddings.m
+++ b/Tests/auts_representing_embeddings.m
@@ -1,0 +1,82 @@
+THRESHOLD := 10^-10;
+
+function find_level_and_chi(F, k)
+  // F: A number field
+  // k: A weight
+  //
+  // Returns a level N and nebentypus character
+  // chi such that HMFSpace(M, N, k, chi)
+  // won't throw any errors.
+  n := Degree(F);
+  for N in IdealsUpTo(100, F) do
+    H := HeckeCharacterGroup(N, [1 .. n]);
+    for chi in Elements(H) do
+      if IsCompatibleWeight(chi, k) then
+        return N, chi;
+      end if;
+    end for;
+  end for;
+end function;
+
+function test(F, k)
+  // F: A number field
+  // k: A weight
+  
+  ZF := Integers(F);
+  n := Degree(F);
+  places := RealPlaces(F);
+
+  K := UnitCharField(F, k);
+  v_0 := DistinguishedPlace(K);
+  a := PrimitiveElement(F);
+
+  auts := AutsReppingEmbeddingsOfF(F, k);
+  assert #auts eq n;
+
+  for i in [1 .. n] do
+    // test that the ith automorphism aut_i in auts satisfies v_1(aut_i(a)) = v_i(a)
+    assert Abs(Evaluate(auts[i](a), v_0) - Evaluate(a, places[i])) lt THRESHOLD;
+  end for;
+  return "";
+end function;
+
+R<x> := PolynomialRing(Rationals());
+
+// TODO abhijitm there are lots of extra tests
+// because at first I thought a more complicated thing
+// was necessary in the nonparitious case. 
+// I'm leaving these in for now in case it
+// later becomes necessary, but once the nonparitious pipeline
+// is running these should be deleted if they're not useful.
+
+// Galois quadratic Q(sqrt(3)), h+/h = 2
+F := QuadraticField(3);
+test(F, [3,2]);
+
+/*
+// Galois cubic 3.3.494209.1, h+/h = 4
+F<a> := NumberField(x^3 - x^2 - 234*x + 729);
+// non-paritious weight
+test(F, [1,2,3]);
+
+
+// non-Galois cubic 3.3.148.1, h+/h = 1
+F<a> := NumberField(x^3 - x^2 - 3*x + 1);
+
+// paritious weight
+test(F, [100, 1000, 11110]);
+// non-paritious weight
+test(F, [1, 246, 1]);
+
+ 
+// Galois cubic 3.3.49.1, h+/h = 1
+F<a> := NumberField(x^3 - x^2 - 2*x + 1);
+// paritious weight
+test(F, [2,2,4]);
+// non-paritious weight
+// because h+ = h all the positive units
+// are squares and unit character field
+// is the same as the splitting field of F
+test(F, [3,5,4]);
+*/
+

--- a/Tests/hecke_stab_33chi.m
+++ b/Tests/hecke_stab_33chi.m
@@ -3,7 +3,7 @@
 // respectively, checks that S_22*f is the Hecke stable subspace of
 // S_44/f
 
-PREC := 17;
+PREC := 12;
 F := QuadraticField(5);
 ZF := Integers(F);
 
@@ -35,9 +35,15 @@ function test(F, N, chi)
   pp := 3*ZF;
   U := HeckeStableSubspace(V, pp);
 
-  // want all of W to be in the Hecke stable subspace of V
-  assert #LinearDependence(U cat W) eq #W;
+  // TODO abhijitm I have absolutely no clue why U cat W does
+  // work but it doesn't seem to so here we are.
+  UcatW := U;
+  for w in W do
+    Append(~UcatW, w);
+  end for;
 
+  // want all of W to be in the Hecke stable subspace of V
+  assert #LinearDependence(UcatW) eq #W;
   return "";
 end function;
 

--- a/Tests/hecke_stab_kernel.m
+++ b/Tests/hecke_stab_kernel.m
@@ -28,4 +28,12 @@ B_22 := CuspFormBasis(M_22);
 // on V. 
 V := [f/eis^2 : f in B_44];
 W := HeckeStableSubspace(V, pp);
-assert #LinearDependence(W cat B_22) eq #B_22;
+
+// TODO abhijitm I have absolutely no clue why U cat W does
+// work but it doesn't seem to so here we are.
+WcatB22 := W;
+for b in B_22 do
+  Append(~WcatB22, b);
+end for;
+
+assert #LinearDependence(WcatB22) eq #B_22;

--- a/Tests/unit_character.m
+++ b/Tests/unit_character.m
@@ -1,0 +1,157 @@
+// code for testing computation of unit characters
+
+/********************** Helper code **********************/
+
+PREC := 10;
+
+function test(M, k, correct : level := 1, chi := 1)
+  /***
+   * M::ModFrmHilDGRng 
+   * k::SeqEnum[RngIntElt]
+   * correct::Assoc[RngOrdIdl -> Assoc[RngOrdElt -> FldNumElt]]
+   * level::RngOrdIdl
+   * chi::GrpHeckeElt
+   ***/
+
+  F := BaseField(M);
+  N := (level cmpeq 1) select 1*Integers(F) else level;
+  H := HeckeCharacterGroup(N, [1,2]);
+  chi := H!chi;
+
+  Mk := HMFSpace(M, N, k, chi);
+  unit_chars := Mk`UnitCharacters;
+
+  // there should be one unit character for each component
+  assert #unit_chars eq NarrowClassNumber(F);
+
+  for bb in NarrowClassGroupReps(M) do
+    uc :=  Mk`UnitCharacters[bb];
+    for eps in TotallyPositiveUnitsGenerators(F) do
+
+      if k eq [3,2] then
+        K := UnitCharField(F, k);
+      end if;
+
+      computed := Evaluate(uc, eps);
+      actual := correct[bb][eps];
+      if computed ne actual then
+        print "Error!";
+        // TODO abhijitm indents in this print statement
+        // are busted whyyyyy
+        printf "At bb = %o, the computed evaluation of the
+        unit character on eps = %o was %o but the true value
+        is %o\n", IdealOneLine(bb), eps, computed, actual;
+      end if;
+      assert computed eq actual;
+    end for;
+  end for;
+  return "";
+end function;
+
+/********************** Q(sqrt(5) **********************/
+
+F := QuadraticField(5);
+ZF := Integers(F);
+prec:= PREC;
+M := GradedRingOfHMFs(F, prec);
+eps := TotallyPositiveUnitsGenerators(F)[1];
+correct := AssociativeArray();
+bb := 1*ZF;
+correct[bb] := AssociativeArray();
+
+//////////////////////// k = [2,2] /////////////////////////
+// parallel weight
+
+k := [2,2];
+K := UnitCharField(F, k);
+
+// in parallel weight the unit character 
+// should be trivial
+correct[bb][eps] := K!1;
+test(M, k, correct);
+
+//////////////////////// k = [2,4] /////////////////////////
+// nonparallel weight
+
+k := [2,4];
+K := UnitCharField(F, k);
+auts := AutsReppingEmbeddingsOfF(F, k);
+
+// eps_1^(k_1/2) * eps_2^(k_2/2) = eps_1 * eps_2^2 = N(eps) * eps_2
+// If [sigma_1, sigma_2] is the output of EmbeddingsIntoUnitCharField and
+// [v_1, v_2] is a list of places then this is also equal to
+// v_1(sigma_2(eps)). The coefficient we store internally should be
+// sigma_2(eps). 
+correct[bb][eps] := auts[2](eps);
+test(M, k, correct);
+
+//////////////////////// k = [3,2] /////////////////////////
+// nonparitious weight
+
+k := [3,2];
+N := 11*ZF;
+H := HeckeCharacterGroup(N, [1,2]);
+chi := H.1; // character of order 11
+K := UnitCharField(F, k);
+                
+// eps_1^(k_1/2) * eps_2^(k_2/2) = eps_1^(3/2) * eps_2 = eps_1^(1/2)
+// The coefficient we store should thus be the positive square root
+// of eps_1. eps = mu^2 for mu = +/- (1+sqrt(5))/2 (under v_1, say).
+// We want the one which is positive under v_1, so (1+sqrt(5))/2.
+v_0 := DistinguishedPlace(K);
+correct[bb][eps] := K!ZF.2;
+test(M, k, correct : level:=N, chi:=chi);
+
+////********************** Q(sqrt(3) **********************////
+
+F := QuadraticField(3);
+ZF := Integers(F);
+prec:= PREC;
+M := GradedRingOfHMFs(F, prec);
+eps := TotallyPositiveUnitsGenerators(F)[1];
+correct := AssociativeArray();
+for bb in M`NarrowClassGroupReps do
+  correct[bb] := AssociativeArray();
+end for;
+
+// parallel weight
+k := [5,5];
+K := UnitCharField(F, k);
+
+for bb in M`NarrowClassGroupReps do
+  correct[bb][eps] := K!1;
+end for;
+test(M, k, correct);
+
+////********************** Galois cubic with discriminant 49 **********************////
+
+// weight [2,2,2] over the non-Galois cubic field 
+// with defining polynomial x^3 - x^2 + 1 
+
+/* TODO (abhijitm) uncomment this once ee2be7d and
+ * its parents land (new multiplication code)
+  
+R<x> := PolynomialRing(Rationals());
+F<a> := NumberField(x^3 - x^2 - 2*x + 1);
+ZF := Integers(F);
+prec:=20;
+M:=GradedRingOfHMFs(F, prec);
+N := 1*ZF;
+M_222 := HMFSpace(M, N, [2,2,2]);
+unitchars := M_222`UnitCharacters;
+// there should be one unit character for each component
+assert #unitchars eq 1;
+
+eps := TotallyPositiveUnitsGenerators(F)[1];
+// the unit character(s) in parallel weight should be trivial
+assert Evaluate(unitchars[1], eps) eq [1];
+
+*/
+
+/********************** non-Galois cubic with discriminant -23 **********************////
+
+// weight [2,3,4] over the non-Galois cubic field 
+// with defining polynomial x^3 - 21 x - 28
+// this captures all the complications of the
+// earlier tests
+


### PR DESCRIPTION
This PR enables unit characters for nonparallel weight HMFs. The output of the unit character lands in the `UnitCharField` defined as part of the coefficient ring logic.