### PR TITLE
support nonparallel weight 

### DIFF
--- a/ModFrmHilD/Basis.m
+++ b/ModFrmHilD/Basis.m
@@ -46,8 +46,6 @@ intrinsic CuspFormBasis(
   GaloisDescent:=true) -> SeqEnum[ModFrmHilDElt]
   {returns a basis for cuspspace of M of weight k}
 
-  require IsParallel(Weight(Mk)) : "not yet implemented for parallel weight";
-
   if assigned Mk`CuspFormBasis then
     return Mk`CuspFormBasis;
   end if;

--- a/ModFrmHilD/Basis.m
+++ b/ModFrmHilD/Basis.m
@@ -130,11 +130,11 @@ intrinsic EisensteinBasis(
 
   if not IsParallel(Weight(Mk)) then
     Mk`EisensteinBasis := [];
+  else
+    k := Weight(Mk)[1];
+    Mk`EisensteinBasis := NewEisensteinBasis(Mk) cat OldEisensteinBasis(Mk);
+    require #Mk`EisensteinBasis eq EisensteinDimension(Mk) : "#Mk`EisensteinBasis = %o != %o = EisensteinDimension(Mk)", #Mk`EisensteinBasis, EisensteinDimension(Mk);
   end if;
-
-  k := Weight(Mk)[1];
-  Mk`EisensteinBasis := NewEisensteinBasis(Mk) cat OldEisensteinBasis(Mk);
-  require #Mk`EisensteinBasis eq EisensteinDimension(Mk) : "#Mk`EisensteinBasis = %o != %o = EisensteinDimension(Mk)", #Mk`EisensteinBasis, EisensteinDimension(Mk);
   return SubBasis(Mk`EisensteinBasis, IdealClassesSupport, Symmetric);
 end intrinsic;
 

--- a/ModFrmHilD/Creation/Newforms.m
+++ b/ModFrmHilD/Creation/Newforms.m
@@ -40,9 +40,11 @@ end intrinsic;
 
 
 // Generic extending multiplicatevely
-intrinsic ExtendMultiplicatively(~coeffs::Assoc, N::RngOrdIdl, k::RngIntElt, chi::., prime_ideals::SeqEnum, ideals::SeqEnum[RngOrdIdl] : factorization:=false)
+intrinsic ExtendMultiplicatively(~coeffs::Assoc, N::RngOrdIdl, k::SeqEnum[RngIntElt], chi::., prime_ideals::SeqEnum, ideals::SeqEnum[RngOrdIdl] : factorization:=false)
   { set a_nn := prod(a_p^e : (p,e) in factorization(nn) }
   // TODO: take character into acount
+
+  k0 := Max(k);
   if factorization cmpeq false then
     factorization := Factorization;
   end if;
@@ -56,14 +58,14 @@ intrinsic ExtendMultiplicatively(~coeffs::Assoc, N::RngOrdIdl, k::RngIntElt, chi
   QX<X, Y> := PolynomialRing(Q, 2);
   R<T> := PowerSeriesRing(QX : Precision := prec);
   recursion := Coefficients(1/(1 - X*T + Y*T^2));
-  // If good, then 1/(1 - a_p T + Chi(p)*Norm(p) T^2) = 1 + a_p T + a_{p^2} T^2 + ...
+  // If good, then 1/(1 - a_p T + Chi(p)*Norm(p)^{k0-1} T^2) = 1 + a_p T + a_{p^2} T^2 + ...
   // If bad, then 1/(1 - a_p T) = 1 + a_p T + a_{p^2} T^2 + ...
   for p in prime_ideals do
     Np := Norm(p);
     if N subset p then
       Npk := 0;
     else
-      Npk := Np^(k - 1);
+      Npk := Np^(k0 - 1);
     end if;
     pe := p;
     Npe := Np;
@@ -119,13 +121,13 @@ intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=t
   end if;
 
   M := Parent(Mk);
+  F := BaseField(M);
   N := Level(Mk);
   NS := Level(S);
   require N subset NS :"The level must divide the level of the target ambient space";
   require AssociatedPrimitiveCharacter(chi) eq AssociatedPrimitiveCharacter(Character(Mk)): "The character of f must match the level of the target ambient space";
   require Weight(S) eq Weight(Mk): "The weight of the form and space do not match";
-  require #SequenceToSet(Weight(S)) eq 1 : "Only implemented for parallel weight";
-  k := Weight(S)[1];
+  k := Weight(S);
 
   divisors := Divisors(N/NS);
   if N eq NS then
@@ -181,16 +183,18 @@ intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=t
 
   // the coefficient ring of the coefficients
   //
-  // if we are performing GaloisDescent, 
+  // If we are performing GaloisDescent, 
   // the best we can do is the field over 
-  // which the Hecke operators are defined
+  // which the Hecke operators are defined.
+  // This field is always contained within 
+  // the UnitCharField(F, k)
   //
-  // if not, then nothing changes and we use the
+  // If not, then nothing changes and we use the
   // field over which the eigenforms themselves
   // are defined
-  R := GaloisDescent select Rationals() else HeckeEigenvalueField(S);
-
+  R := GaloisDescent select UnitCharField(F, k) else HeckeEigenvalueField(S);
   res := [];
+
   for dd in divisors do
     ddinv := dd^-1;
     // coefficients by bb
@@ -218,7 +222,14 @@ intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=t
           // whose entries are the nnth Fourier coefficient of f_1, ..., f_n. 
           // By linearity, the trace of this product is the nnth Fourier coefficient
           // of T^i(f_1 + ... + f_n) as desired. 
-          CoeffsArray[i][bb][nu] := R!(bool select Trace(Tzeta_powers[i]*v) else 0);
+          a_nn := Trace(Tzeta_powers[i]*v);
+          if nn eq 0*ZF then
+            // apparently the norm of the zero ideal is not defined
+            // so we treat this case separately
+            CoeffsArray[i][bb][nu] := R!0;
+          else
+            CoeffsArray[i][bb][nu] := R!(bool select IdlCoeffToEltCoeff(a_nn, nu, k, R, F) else 0);
+          end if;
         end for;
       end for;
     end for;
@@ -228,8 +239,6 @@ intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=t
   end for;
   return res;
 end intrinsic;
-
-
 
 intrinsic OldCuspForms(MkN1::ModFrmHilD, MkN2::ModFrmHilD : GaloisDescent:=true) -> SeqEnum[ModFrmHilDElt]
   {return the inclusion of MkN1 into MkN2}

--- a/ModFrmHilD/Creation/Newforms.m
+++ b/ModFrmHilD/Creation/Newforms.m
@@ -15,6 +15,7 @@ intrinsic MagmaNewformDecomposition(Mk::ModFrmHilD) -> List
     MF := HilbertCuspForms(Mk);
     vprintf HilbertModularForms: "new ";
     New := NewSubspace(MF);
+    SetRationalBasis(New);
     vprintf HilbertModularForms: "hecke character subspace ";
     S := HeckeCharacterSubspace(New, Character(Mk));
     vprintf HilbertModularForms: "decomposition...";

--- a/ModFrmHilD/Creation/Newforms.m
+++ b/ModFrmHilD/Creation/Newforms.m
@@ -87,7 +87,24 @@ end intrinsic;
 
 // Eigenforms new/old in Mk
 intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=true) -> SeqEnum[ModFrmHilDElt]
-  {return the inclusions of f, as ModFrmHil(Elt), into M}
+  {
+    return the inclusions of f, as ModFrmHil(Elt), into M
+
+    Given an eigenform of type ModFrmHil (Magma's internal HMF type) 
+    with coefficients in a field L/F, where F is the base field for the 
+    space of HMFs, let V be the dimension [L:F] vector space of HMFs spanned 
+    by f and its conjugates.
+
+    This function returns a list of [L:F] forms of type ModFrmHilD 
+    -- defined over a subfield of the splitting field of F --
+    which span V. 
+
+
+    In general, the field of definition will be the smallest field over which
+    the Hecke operators are defined. See 
+    https://magma.maths.usyd.edu.au/magma/handbook/text/1735
+    for some more about this. 
+  }
 
   if Type(f) eq ModFrmHil then
     S := f;
@@ -125,6 +142,9 @@ intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=t
 
   if GaloisDescent then
     fn := func<pp|Matrix(HeckeOperator(S, pp))>;
+    // Tzeta is the matrix of a generator for the Hecke algebra
+    // (it has a generator because the Hecke algebra is isomorphic
+    // to a number field). 
     T , _, _, _, _, Tzeta, _ := Explode(hecke_algebra(S : generator:=true));
     if Order(chi) in [1,2] then
       chiH := chi;
@@ -159,6 +179,14 @@ intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=t
   Tzeta_powers := [Tzeta^i : i in [0..Nrows(Tzeta) - 1]];
 
   // the coefficient ring of the coefficients
+  //
+  // if we are performing GaloisDescent, 
+  // the best we can do is the field over 
+  // which the Hecke operators are defined
+  //
+  // if not, then nothing changes and we use the
+  // field over which the eigenforms themselves
+  // are defined
   R := GaloisDescent select Rationals() else HeckeEigenvalueField(S);
 
   res := [];
@@ -179,6 +207,16 @@ intrinsic Eigenforms(Mk::ModFrmHilD, f::Any, chi::GrpHeckeElt : GaloisDescent:=t
           v := 0;
         end if;
         for i in [1..Nrows(Tzeta)] do
+          // Let f_j be the jth Galois conjugate of f and T a generator
+          // for the Hecke algebra. Then, the ith basis vector that we output is
+          // T^i * (f_1 + ... + f_n). 
+          //
+          // To see why this is what the code is doing, think in the eigenbasis.
+          // Then, Tzeta_powers[i] = T^i is a diagonal matrix.
+          // The element v is the nnth Hecke operator, or equivalently, a diagonal matrix
+          // whose entries are the nnth Fourier coefficient of f_1, ..., f_n. 
+          // By linearity, the trace of this product is the nnth Fourier coefficient
+          // of T^i(f_1 + ... + f_n) as desired. 
           CoeffsArray[i][bb][nu] := R!(bool select Trace(Tzeta_powers[i]*v) else 0);
         end for;
       end for;

--- a/ModFrmHilD/FldExt.m
+++ b/ModFrmHilD/FldExt.m
@@ -463,7 +463,6 @@ intrinsic EltToShiftedHalfWeight(x::FldElt, k::SeqEnum[RngIntElt]) -> FldElt
 
       The element y will lie in the UnitCharField(F,k). 
   }
-
   assert IsTotallyPositive(x);
   if not IsParitious(k) then
     assert Norm(x) eq 1;
@@ -489,7 +488,6 @@ intrinsic EltToShiftedHalfWeight(x::FldElt, k::SeqEnum[RngIntElt]) -> FldElt
   end if;
 end intrinsic;
 
-
 intrinsic PositiveInPlace(nu::FldNumElt, v::PlcNumElt) -> FldNumElt
   {
     input: 
@@ -499,4 +497,31 @@ intrinsic PositiveInPlace(nu::FldNumElt, v::PlcNumElt) -> FldNumElt
       nu if v(nu) > 0 and -nu otherwise.
   }
   return (Evaluate(nu, v) gt 0) select nu else -1*nu;
+end intrinsic;
+
+intrinsic PositiveSqrt(nu::FldNumElt, K::FldNum) -> FldNumElt
+  {
+    input:
+      nu: An element of a number field F
+      K: A number field containing nu and a square root of nu.
+    return:
+      mu such that mu^2 = nu and mu is positive in the distinguished
+      place of K.
+  }
+  mu := Sqrt(K!nu);
+  v_0 := DistinguishedPlace(K);
+  return (Evaluate(mu, v_0) ge 0) select mu else -1*mu;
+end intrinsic;
+
+intrinsic NormToHalfWeight(I::RngFracIdl, k0::RngIntElt, K::FldNum) -> FldNumElt
+  {
+    input:
+      I: A fractional ideal
+      k0: A nonnegative integer
+      K: A number field containing Norm(I)^(k0/2)
+    return:
+      Norm(I)^(k0/2)
+  }
+  Nm := K!Norm(I);
+  return (k0 mod 2 eq 0) select Nm^(ExactQuotient(k0, 2)) else Nm^(k0/2);
 end intrinsic;

--- a/ModFrmHilD/Hecke.m
+++ b/ModFrmHilD/Hecke.m
@@ -16,6 +16,7 @@ intrinsic HeckeOperator(f::ModFrmHilDElt, mm::RngOrdIdl : MaximalPrecision := fa
   k := Weight(f);
   k0 := Max(k);
   chi := Character(Mk);
+  K := CoefficientRing(f);
 
   coeffsTmmf := AssociativeArray();
   prec := AssociativeArray();
@@ -41,7 +42,7 @@ intrinsic HeckeOperator(f::ModFrmHilDElt, mm::RngOrdIdl : MaximalPrecision := fa
       for aa in Divisors(ZF!!(nn + mm)) do
         if nn eq 0*ZF then
           //takes care if the coefficients for the zero ideal are different
-          c +:= chi(aa) * Norm(aa)^(k0 - 1) * Coefficients(f)[NarrowClassRepresentative(M, bb*mm/aa^2)][ZF!0];
+          c +:= StrongMultiply(K, [* chi(aa), Norm(aa)^(k0 - 1), Coefficients(f)[NarrowClassRepresentative(M, bb*mm/aa^2)][ZF!0] *]);
         else
           b, cf := IsCoefficientDefined(f, ZF!!(aa^(-2) * nn * mm));
           if not b then
@@ -50,7 +51,7 @@ intrinsic HeckeOperator(f::ModFrmHilDElt, mm::RngOrdIdl : MaximalPrecision := fa
             prec[bb] := t-1;
             break; // breaks loop on aa
           else
-            c +:= chi(aa) * Norm(aa)^(k0 - 1) * cf;
+            c +:= StrongMultiply(K, [* chi(aa),  Norm(aa)^(k0 - 1), cf *]);
           end if;
         end if;
       end for;

--- a/ModFrmHilD/Hecke.m
+++ b/ModFrmHilD/Hecke.m
@@ -13,7 +13,8 @@ intrinsic HeckeOperator(f::ModFrmHilDElt, mm::RngOrdIdl : MaximalPrecision := fa
   F := BaseField(M);
   Cl, mp := NarrowClassGroup(F);
   ZF := Integers(F);
-  k0 := Max(Weight(f));
+  k := Weight(f);
+  k0 := Max(k);
   chi := Character(Mk);
 
   coeffsTmmf := AssociativeArray();
@@ -56,7 +57,7 @@ intrinsic HeckeOperator(f::ModFrmHilDElt, mm::RngOrdIdl : MaximalPrecision := fa
       if prec[bb] ne 0 then // the loop on aa didn't finish
         break; // breaks loop on nu
       else
-        coeffsTmmf[bb][nu] := c;
+        coeffsTmmf[bb][nu] := IdlCoeffToEltCoeff(c, nu, k, CoefficientRing(Components(f)[bb]), F);
       end if;
     end for;
   end for;

--- a/ModFrmHilD/Space.m
+++ b/ModFrmHilD/Space.m
@@ -432,6 +432,13 @@ end intrinsic;
 intrinsic CuspDimension(Mk::ModFrmHilD : version:="trace") -> RngIntElt
   {return dimension of S(Mk)}
   require version in ["builtin", "trace"] : "the options for trace are either \"builtin\" or \"trace formula\"";
+
+  // the trace formula does not currently support
+  // nonparallel weight
+  if not IsParallel(Weight(Mk)) then
+    version := "builtin";
+  end if;
+  
   // FIXME: Ben will fix this eventually...
   if not Mk`Ambient then
     version := "builtin";

--- a/Tests/elt_idl_coeff_conversion.m
+++ b/Tests/elt_idl_coeff_conversion.m
@@ -1,0 +1,142 @@
+BOUND := 10;
+TRIALS := 25;
+PREC := 1;
+
+function random_totally_positive(F, bound)
+  // F: FldNum  
+  // bound: RngIntElt -- a bound on how large a norm we allow
+  
+  // This is incredibly sketchy, but 
+  // it's probably good enough??
+  //
+  // Takes a random element of F of norm at most
+  // Sqrt(bound), squares it to get a totally positive 
+  // element, and then subtracts a rational y that 
+  // leaves x^2 - y totally positive. 
+
+  DUMB := 7;
+  x := 0;
+  while x eq 0 do
+    x := Random(F, Floor(Sqrt(bound)));
+  end while;
+
+  x2 := x^2;
+  places := RealPlaces(F);
+  min_coord := Floor(Min([Evaluate(x2, v) : v in places]));
+  denom := Random([2 .. DUMB]);
+  y := F!(min_coord/denom);
+  z := x2 - y;
+  assert IsTotallyPositive(z);
+  return z;
+end function;
+
+// The usual Magma assert statement doesn't tell you
+// what the two values were when an assertion fails. 
+// This is an attempt to remedy that.
+function assert_eq(x, y)
+  // x: Any
+  // y: Any
+  if x cmpne y then
+    print "Failure! %o is not equal to %o \n", x, y;
+    assert x eq y;
+  end if;
+  return "";
+end function;
+
+function test(F, K, k, bbps, idl_to_elt, elt_to_idl : bound := BOUND)
+  // F: FldNum - number field
+  // k: SeqEnum[RngIntElt] - weight (sequence of nonnegative integers)
+  // idl_to_elt: UserProgram - a function taking a_nn and nu and computing a_nu
+  // elt_to_idl: UserProgram - a function taking a_nu and nu and computing a_nn
+  
+  // TODO abhijitm is this the right field in general
+  for _ in [1 .. BOUND] do
+    a :=  Random(K, 100);
+    nu := random_totally_positive(F, 100);
+    bbp := Random(bbps);
+    if not (a eq 0 or nu eq 0) then
+      // TODO abhijitm decide whether or not there's a bbp dependence,
+      // if not remove the bbp's everywhere in this test.
+      x := IdlCoeffToEltCoeff(a, nu, k, K, F);
+      y := EltCoeffToIdlCoeff(a, nu, k, K, F);
+      assert_eq(x, idl_to_elt(a, nu, bbp));
+      assert_eq(y, elt_to_idl(a, nu, bbp));
+      assert_eq(EltCoeffToIdlCoeff(x, nu, k, K, F), a);
+      assert_eq(IdlCoeffToEltCoeff(y, nu, k, K, F), a);
+    end if;
+  end for;
+  print "Passed test!";
+  return "";
+end function;
+
+/////// NARROW CLASS NUMBER 1
+
+F := QuadraticField(5);
+ZF := Integers(F);
+M := GradedRingOfHMFs(F, PREC);
+N := 1*ZF;
+dd := Different(ZF);
+bbps := M`NarrowClassGroupRepsToIdealDual;
+
+// PARALLEL WEIGHT
+
+k := [2, 2];
+K := UnitCharField(F, k);
+// because the weight is parallel
+// and h+ = 1, a_nn = a_nu always
+idl_to_elt := func<a, nu, bbp | a>;
+elt_to_idl := func<a, nu, bbp | a>;
+test(F, K, k, bbps, idl_to_elt, elt_to_idl);
+
+// K bigger than UnitCharField
+K := Compositum(UnitCharField(F, k), CyclotomicField(7));
+test(F, K, k, bbps, idl_to_elt, elt_to_idl);
+
+// EVEN PARITIOUS WEIGHT
+
+k := [2, 4];
+K := UnitCharField(F, k);
+idl_to_elt := func<a, nu, bbp | a*nu^(-1)>;
+elt_to_idl := func<a, nu, bbp | a*nu>;
+test(F, K, k, bbps, idl_to_elt, elt_to_idl);
+
+k := [6, 2];
+K := UnitCharField(F, k);
+auts := AutsReppingEmbeddingsOfF(F, k);
+idl_to_elt := func<a, nu, bbp | a*auts[2](nu^(-2))>;
+elt_to_idl := func<a, nu, bbp | a*auts[2](nu^2)>;
+test(F, K, k, bbps, idl_to_elt, elt_to_idl);
+
+// ODD PARITIOUS WEIGHT
+// TODO abhijitm add if necessary
+
+// NONPARITIOUS WEIGHT
+// TODO abhijitm 
+
+
+/////// NARROW CLASS NUMBER 2
+F := QuadraticField(3);
+ZF := Integers(F);
+N := 1*ZF;
+M := GradedRingOfHMFs(F, PREC);
+dd := Different(ZF);
+bbps := M`NarrowClassGroupRepsToIdealDual;
+
+// PARALLEL WEIGHT
+
+k := [2, 2];
+K := UnitCharField(F, k);
+elt_to_idl := func<a, nu, bbp | a>;
+idl_to_elt := func<a, nu, bbp | a>;
+test(F, K, k, bbps, idl_to_elt, elt_to_idl);
+
+// EVEN PARITIOUS WEIGHT
+
+k := [2, 4];
+K := UnitCharField(F, k);
+idl_to_elt := func<a, nu, bbp | a*nu^(-1)>;
+elt_to_idl := func<a, nu, bbp | a*nu>;
+test(F, K, k, bbps, idl_to_elt, elt_to_idl);
+
+// NONPARITIOUS WEIGHT
+// TODO abhijitm

--- a/Tests/hecke_op_test.m
+++ b/Tests/hecke_op_test.m
@@ -1,6 +1,3 @@
-// These are tests
-load "config.m";
-
 // Narrow class number 1
 //Basis for level 1 weight [4,4] consists of an eigenstein series and an eigenform
 D := 13;
@@ -17,11 +14,11 @@ g:=B[2];
 L:=LinearDependence([HeckeOperator(f, 2*ZF), 65*f]);
 assert L eq [[1, -1]]; // f is an Eisenstein series and is indeed an eigenvalue
 for x:=2 to 7 do
-  Lx:=LinearDependence([HeckeOperator(g, I[x]), Coefficients(g)[1*ZF][I[x]]*g]);
+  b, c := IsCoefficientDefined(g, I[x]);
+  assert b;
+  Lx:=LinearDependence([HeckeOperator(g, I[x]), c*g]);
   assert Lx eq [[1, -1]];
 end for;
-
-
 
 
 // Narrow class number > 1
@@ -42,7 +39,3 @@ nn:=Factorisation(11*ZF)[1][1];
 f:=HeckeOperator(E4, nn);
 L:=LinearDependence([f, E4]);
 assert L eq [[ 1, -1332 ]]; // f is an Eisenstein series and is indeed an eigenvalue
-
-
-
-// Tests for characters?

--- a/Tests/hecke_stab_24.m
+++ b/Tests/hecke_stab_24.m
@@ -1,0 +1,48 @@
+// Given a weight [1,1] Eisenstein series E with quadratic nebentypus, 
+// and writing S_24 and S_46 for the weight [2,4] and [4,6] cusp forms,
+// checks that S_24 * E^2 is contained in S_46 and that
+// applying Hecke stability to S_46/E^2 recovers S_24. 
+
+F := QuadraticField(5);
+ZF := Integers(F);
+prec := 11;
+pp := 2*ZF;
+M := GradedRingOfHMFs(F, prec);
+triv_char := HeckeCharacterGroup(1*ZF, [1,2]).0;
+
+N := Factorization(41*ZF)[1][1];
+H := HeckeCharacterGroup(N, [1,2]);
+chi := H.1;
+
+M11chi := HMFSpace(M, N, [1,1], chi);
+eis := EisensteinSeries(M11chi, chi, triv_char);
+
+k_lo := [2,4];
+k_hi := [4,6];
+
+M_lo := HMFSpace(M, N, k_lo);
+M_hi := HMFSpace(M, N, k_hi);
+
+B_hi := CuspFormBasis(M_hi);
+B_lo := CuspFormBasis(M_lo);
+
+// B_lo should be Hecke stable
+HB_lo := [HeckeOperator(f, pp) : f in B_lo];
+assert #LinearDependence(B_lo cat HB_lo) eq #B_lo;
+
+// B_hi should be Hecke stable
+HB_hi := [HeckeOperator(f, pp) : f in B_hi];
+assert #LinearDependence(B_hi cat HB_hi) eq #B_hi;
+
+// dependence of B_hi with eis^2 * B_lo should be 
+// the dimension of B_lo
+x := #LinearDependence(B_hi cat [f * eis^2 : f in B_lo]);
+assert x eq #B_lo;
+
+// If we divide B_hi by eis^2, we should get
+// a space of meromorphic quotients which contains B_lo, and 
+// the Hecke stable subspace should actually be B_lo
+V := [f/eis^2 : f in B_hi];
+W := HeckeStableSubspace(V, pp);
+assert #LinearDependence(W cat B_lo) eq #B_lo;
+

--- a/Tests/nonparallel_weight.m
+++ b/Tests/nonparallel_weight.m
@@ -1,0 +1,99 @@
+function hecke_eigs(F, N, k, MD)
+  /***
+   * F::FldNum - Base field of HMFs
+   * N::RngOrdideal - Level 
+   * k::SeqEnum[RngIntElt] - Weight
+   * MD::ModFrmHilDGRng - A graded ring of HMFs (our version)
+   ***/
+  M := HilbertCuspForms(F, N, k);
+  H := HeckeCharacterGroup(N, [1,2]);
+  triv := H!1;
+  New := NewSubspace(M);
+  ND := NewformDecomposition(New);
+  // this function should be called on
+  // (F, N, k) tuples which have a unique
+  // eigenform for consistency
+  assert #ND eq 1;
+  eig := Eigenform(ND[1]);
+
+  ideals := Ideals(MD);
+  primes := PrimeIdeals(MD);
+  
+  hecke_eig_dict := AssociativeArray();
+  for pp in primes do
+    hecke_eig_dict[pp] := HeckeEigenvalue(eig, pp);
+  end for;
+
+  ZF := Integers(MD);
+  hecke_eig_dict[0*ZF] := 0;
+  hecke_eig_dict[1*ZF] := 1;
+
+  ExtendMultiplicatively(~hecke_eig_dict, N, k, triv, primes, ideals : factorization:=func<n|Factorization(MD, n)>);
+  return hecke_eig_dict;
+end function;
+
+F := QuadraticField(5);
+ZF := Integers(F);
+prec := 14;
+M := GradedRingOfHMFs(F, prec);
+nns := Ideals(M);
+
+N := 7*ZF;
+k := [2, 4];
+
+hecke_eigs_dict := hecke_eigs(F, N, k, M);
+K := Parent(hecke_eigs_dict[2*ZF]);
+
+f1_elt_coeffs := AssociativeArray();
+f2_elt_coeffs := AssociativeArray();
+
+bb := 1*ZF;
+f1_elt_coeffs[bb] := AssociativeArray();
+f2_elt_coeffs[bb] := AssociativeArray();
+
+reps := ShintaniRepsUpToTrace(M, bb, prec);
+
+for nn in Ideals(M) do
+  nu := IdealShitaniReps(M)[bb][nn];
+  f1_idl_coeff := Trace(K!hecke_eigs_dict[nn]);
+  f2_idl_coeff := Trace(K.1 * hecke_eigs_dict[nn]);
+  if nu eq 0 then
+    f1_elt_coeffs[bb][nu] := F!0;
+    f2_elt_coeffs[bb][nu] := F!0;
+  else
+    f1_elt_coeffs[bb][nu] := F!f1_idl_coeff * (nu)^(-1);
+    f2_elt_coeffs[bb][nu] := F!f2_idl_coeff * (nu)^(-1);
+  end if;
+end for;
+
+M24 := HMFSpace(M, N, k);
+B24 := CuspFormBasis(M24); // two conjugate (over F) eigenforms
+B24_true := [HMF(M24, f1_elt_coeffs), HMF(M24, f2_elt_coeffs)];
+
+// Bases should be linearly independent 
+assert #LinearDependence(B24) eq 0;
+assert #LinearDependence(B24_true) eq 0;
+
+// Computed basis should agree with the true basis
+assert #LinearDependence(B24 cat B24_true) eq 2;
+
+M22 := HMFSpace(M, N, [2, 2]);
+M46 := HMFSpace(M, N, [4, 6]);
+M48 := HMFSpace(M, N, [4, 8]);
+
+// there is exactly one [2,2] form of this level
+h := CuspFormBasis(M22)[1];
+B46 := CuspFormBasis(M46);
+B48 := CuspFormBasis(M48);
+
+// Bases should be linearly independent 
+assert #LinearDependence(B46) eq 0;
+assert #LinearDependence(B48) eq 0;
+
+// if h is a [2,2] form, S24*h should be contained in S48
+h_times_B24 := [h*f : f in B24];
+assert #LinearDependence(B46 cat h_times_B24) eq #B24;
+
+// the square of S24 should be contained in S48
+B24_squared := [f^2 : f in B24];
+assert #LinearDependence(B48 cat B24_squared) eq #B24;

--- a/Tests/partial_wt_one.m
+++ b/Tests/partial_wt_one.m
@@ -1,0 +1,51 @@
+/****************************************************************
+* Finds a weight [3,1] CM form of level a prime above 41.
+* TODO abhijitm add a check to match this with the 
+* class field theory computation.
+****************************************************************/
+
+F := QuadraticField(5);
+prec := 17;
+ZF := Integers(F);
+M := GradedRingOfHMFs(F, prec);
+N := Factorization(41*ZF)[1][1];
+H := HeckeCharacterGroup(N, [1,2]);
+chi := H.1;
+M13chi := HMFSpace(M, N, [3,1], chi);
+B13chi := HeckeStabilityCuspBasis(M13chi);
+
+assert #B13chi eq 1;
+
+/****************************************************************
+* Finds a weight [3,1] form of level 14 and order 6 nebentypus.
+* Because the nebentypus is not quadratic, this form is not CM.
+* This reproduces the example constructed by Moy and Specter in
+* https://arxiv.org/abs/1407.3872
+*
+* TODO abhijitm implement the holomorphicity checking step.
+* For now we just find a 2-dimensional Hecke-stable subspace
+****************************************************************/
+
+F := QuadraticField(5);
+ZF := Integers(F);
+prec := 25;
+M := GradedRingOfHMFs(F, prec);
+N := 14*ZF;
+H := HeckeCharacterGroup(N, [1,2]);
+H_prim := HeckeCharacterGroup(7*ZF, [1,2]);
+chi_prim := (H_prim).1;
+chi := H.1;
+M15chi := HMFSpace(M, N, [1,5], chi);
+
+M26 := HMFSpace(M, N, [2,6]);
+B26 := CuspFormBasis(M26);
+
+MEis := HMFSpace(M, N, [1,1], chi^-1);
+
+triv_char := HeckeCharacterGroup(1*ZF, [1, 2]).0;
+E := EisensteinSeries(MEis, chi_prim^-1, triv_char);
+V := [f/E : f in B26];
+
+pp := 3*ZF;
+U := HeckeStableSubspace(V, pp);
+assert #U eq 2;


### PR DESCRIPTION
This PR enables computation of Hilbert modular forms with nonparallel weight. 

One important change is addition of functions `IdlCoeffToEltCoeff` and `EltCoeffToIdlCoeff` to pass between the Fourier coefficient associated to a totally positive element $\nu$ and the coefficient associated to the corresponding ideal $\mathfrak{n}$. The conversion more or less follows (2.24) from [this](https://projecteuclid.org/journals/duke-mathematical-journal/volume-45/issue-3/The-special-values-of-the-zeta-functions-associated-with-Hilbert/10.1215/S0012-7094-78-04529-5.full) paper of Shimura. The point is that this conversion is trivial in the parallel weight case but when the weight is nonparallel some changes need to be made. 

There are several tests which were added as well. In particular, we (almost) reproduce Moy-Specter and identify the 2-dimensional Hecke stable subspace of the same level and character as the one that they find. (They have an ad hoc way of verifying that these forms are holomorphic which we don't include in this test.)