### PR TITLE
Igusa test bug fix

### DIFF
--- a/ModFrmHilD/Creation/Igusa.m
+++ b/ModFrmHilD/Creation/Igusa.m
@@ -123,8 +123,8 @@ intrinsic SiegelEisensteinPullback(M::ModFrmHilDGRng, k::SeqEnum[RngIntElt]) -> 
   end for;
 
   // creates an HMF only supported at bb
-  fplus := HMF(HMFComp(Mkplus, bb, fpluscoeffs));
-  fminus := HMF(HMFComp(Mkminus, bb, fminuscoeffs));
+  fplus := HMF(cModFrmHilDEltComp(Mkplus, bb, fpluscoeffs));
+  fminus := HMF(cModFrmHilDEltComp(Mkminus, bb, fminuscoeffs));
   return fplus, fminus;
 end intrinsic;
 

--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -212,7 +212,7 @@ end intrinsic;
 
 intrinsic HMF(fbb::ModFrmHilDEltComp) -> ModFrmHilDElt
   {f = fbb}
-  f := HMFZero(Parent(fbb));
+  f := HMFZero(Space(fbb));
   f`Components[ComponentIdeal(fbb)] := Copy(fbb);
   return f;
 end intrinsic;


### PR DESCRIPTION
HMFZero takes a ModFrmHilD which is the space of a component, while the parent of a component is of type HMFSerPuis