### PR TITLE
hecke label hotfix

### DIFF
--- a/Tests/_save_and_load_basis.m
+++ b/Tests/_save_and_load_basis.m
@@ -61,7 +61,7 @@ print "thing 3";
 N := 7*ZF;
 M24 := HMFSpace(M, N, [2, 4]);
 S24 := CuspFormBasis(M24);
-correct_prefix := "-5.0.1=49.1=2.4=1u0u1.2u";
+correct_prefix := "-5.0.1=49.1=2.4=1u0.0u1.2u";
 test(M24, S24, correct_prefix);
 
 // uncomment once cubic field stuff works without errors

--- a/Tests/hecke_char_label.m
+++ b/Tests/hecke_char_label.m
@@ -45,9 +45,9 @@ assert #sub<G | [gen @@ mp : gen in rcg_gens]> eq #G;
 ZF := Integers(F);
 N := ideal<ZF | -88*ZF.2 - 48>;
 H := HeckeCharacterGroup(N, [1,2]);
-chi := ChiLabelToHeckeChar("6u2.4.1.2u1.2u", N);
-correct_cond := ideal<ZF | 152, 16*$.2 + 64>;
-// fixed "external consistency" check 
+chi := ChiLabelToHeckeChar("6u5.4.4.5u1.2u", N);
+// "external consistency" check 
+correct_cond := ideal<ZF | 76, 8*$.2 + 32>;
 assert Conductor(chi) eq correct_cond;
 
 // test trivial character on nontrivial ray class group
@@ -57,7 +57,6 @@ assert test_chi(H.0) eq "1u0.0.0.0u1.2u";
 N := 1*ZF;
 H := HeckeCharacterGroup(N, []);
 assert test_chi(H.0) eq "1uuu";
-
 
 // random internal consistency check
 for _ in [1 .. NUM_TRIALS] do


### PR DESCRIPTION
I implemented something completely wrong which somehow passed the tests. No clue how, but this version should actually be correct but with weaker guarantees: the labels are no longer guaranteed to be "minimal length" but the length is still bounded by log Nm(N) + nlog n + log(Delta_F)/2 I think. 
