### PR TITLE
HMFGrossenchars and nonparallel dihedral forms

### DIFF
--- a/ModFrmHilD/Basis.m
+++ b/ModFrmHilD/Basis.m
@@ -315,10 +315,9 @@ end intrinsic;
 
 intrinsic NewDihedralBasis(Mk::ModFrmHilD) -> SeqEnum[ModFrmHilDElt]
   {Given a space of weight one forms, compute the subspace of dihedral forms.} 
-  require IsParallel(Weight(Mk)) and Weight(Mk)[1] eq 1 : "Dihedral forms are only defined for spaces of weight one forms.";
   
   ans := [];
-  for psi in PossibleHeckeCharacters(Mk) do
+  for psi in PossibleGrossenchars(Mk) do
     Append(~ans, ThetaSeries(Mk, AssociatedPrimitiveCharacter(psi)));
   end for;
   

--- a/ModFrmHilD/Creation/CuspFormFromEigs.m
+++ b/ModFrmHilD/Creation/CuspFormFromEigs.m
@@ -47,7 +47,7 @@ intrinsic ExtendMultiplicatively(~coeffs::Assoc, N::RngOrdIdl, k::SeqEnum[RngInt
   // extend multiplicatively
   for n in ideals do
     if not IsDefined(coeffs, n) then
-      coeffs[n] := &*[coeffs[pair[1]^pair[2]] : pair in factorization(n)];
+      coeffs[n] := StrongMultiply([* coeffs[pair[1]^pair[2]] : pair in factorization(n) *]);
     end if;
   end for;
 end intrinsic;

--- a/ModFrmHilD/Creation/Dihedral.m
+++ b/ModFrmHilD/Creation/Dihedral.m
@@ -50,150 +50,221 @@ end function;
 
 //////////////////////////////// Conjugates of Grossencharacters
 
-intrinsic ConjugateIdeal(K::FldNum, N::RngOrdIdl) -> RngOrdIdl
+intrinsic ConjugateIdeal(K::Fld, F::Fld, N::RngOrdIdl) -> RngOrdIdl
   {
     inputs:
-      K - A relative quadratic extension
-      N - An ideal of K
-    returns
+      K - An absolute number field
+      F - A field such that K/F is a quadratic extension
+      N - An ideal of the ring of integers of K
+    returns:
       The conjugate of N.
   }
-  require Degree(K) eq 2 : "K is not a quadratic extension of its base field";
-  ZK := Integers(K);
+  require IsSubfield(F, K) : "F is not a subfield of K";
+  K_rel := RelativeField(F, K);
+  require Degree(K_rel) eq 2 : "K is not a quadratic extension of F";
+  ZK_rel := Integers(K_rel);
+  N_rel := ZK_rel!!N;
 
   // the nontrivial automorphism of K
-  aut := Automorphisms(K)[2];
-  conj_gens := [aut(gen) : gen in Generators(N)];
-  return ideal<ZK| conj_gens>;
+  aut := Automorphisms(K_rel)[2];
+  conj_gens := [aut(gen) : gen in Generators(N_rel)];
+  return Integers(K)!!(ideal<ZK_rel | conj_gens>);
+end intrinsic;
+
+intrinsic PrunedGrossencharsSet(X::HMFGrossencharsTorsor, F::Fld) -> SetEnum
+  {
+    input:
+      X - A HMFGrossencharTorsor of finite order characters
+        over a field K with modulus N.
+      F - A number field such that K/F is a quadratic extension
+        and N is stable under the Gal(K/F) action
+    returns:
+      The set of characters in chi which are not self-conjugate
+      under the K/F action, up to conjugation. 
+  }
+  require IsFiniteOrder(X) : "Cannot compute conjugate pairs of\
+      infinite order Grossencharacters";
+  K := X`BaseField;
+  require IsSubfield(F, K) : "F is not a subfield of K";
+
+  S := HMFGrossencharsTorsorSet(X);
+
+  // If the order of S is 1 then the ray class group is trivial
+  // and the trivial character is self-conjugate
+  if #S eq 1 then
+    return {};
+  end if;
+
+  N_f, N_oo := Modulus(X); 
+  H := HeckeCharacterGroup(N_f, N_oo);
+  G, mp := RayClassGroup(N_f, N_oo);
+  gens := Generators(G);
+  idl_gens := [mp(g) : g in gens];
+  lcm_order := LCM([Order(g) : g in gens]); 
+  L := CyclotomicField(lcm_order);
+
+  chi_to_evals := AssociativeArray();
+  evals_to_chi := AssociativeArray();
+
+  pairs := [];
+
+  for chi in S do
+    chi_evals := [StrongCoerce(L, chi(I)) : I in idl_gens]; 
+    chi_to_evals[chi`RayClassChar] := chi_evals;
+    evals_to_chi[chi_evals] := chi;
+  end for;
+
+  chis := S;
+  pruned_chis := {};
+  while not IsEmpty(chis) do
+    chi := Rep(chis);
+    chi_evals := chi_to_evals[chi`RayClassChar];
+    conj_chi_evals := [StrongCoerce(L, chi(ConjugateIdeal(K, F, I))) : I in idl_gens];
+    // include chi in the set of pruned chis if
+    // chi isn't self-conjugate
+    if chi_evals ne conj_chi_evals then
+      Include(~pruned_chis, chi);
+    end if;
+    // remove chi and its conjugate
+    assert evals_to_chi[conj_chi_evals] in chis;
+    assert chi in chis;
+    Exclude(~chis, evals_to_chi[conj_chi_evals]);
+    Exclude(~chis, chi);
+  end while;
+  return pruned_chis;
 end intrinsic;
 
 //////////////////////////////// Computing Grossencharacters
 
-intrinsic PossibleHeckeCharactersOfK(
-  F::FldNum, 
-  N::RngOrdIdl, 
-  K::FldNum, 
-  chi::GrpHeckeElt : 
-  prune := true
-  ) -> SeqEnum[GrpHeckeElt]
-  {
-    Given a totally real field F, an ideal N of F, a character chi of modulus N,
-    and a quadratic extension K of discriminant dividing N, computes all finite 
-    order non-Galois-invariant Hecke characters of conductor dividing N/disc(K) 
-    whose restriction is chi.
+function OrderedPlacesOfCMField(K, F : Precision:=25)
+  // K - a number field, CM over F
+  // F - a number field
+  //
+  // returns a SeqEnum[RngIntElt] whose ith entry
+  // is the index of the place of F lying underneath
+  // the ith infinite place of K (in the orderings given by
+  // InfinitePlaces(F) and InfinitePlaces(K), respectively).
+  
+  // check that K/F is a CM extension
+  assert IsTotallyReal(F);
+  assert IsTotallyComplex(K);
+  assert IsSubfield(F, K);
+  assert Degree(K) eq 2*Degree(F);
 
-    If the optional parameter prune is true, we only keep on copy of chi and  
-    the conjugate of chi, since both of these lift to the same Hilbert modular form.
+  n := Degree(F);
+  F_places := InfinitePlaces(F);
+  K_places := InfinitePlaces(K);
+  a := F.1;
+  a_embed_dict := AssociativeArray();
+  for i in [1 .. n] do
+    a_i := Round(10^Precision * Evaluate(a, F_places[i]));
+    a_embed_dict[a_i] := i;
+  end for;
+
+  lies_over := [];
+  for i in [1 .. n] do
+    b_i := Round(10^Precision * Evaluate(K!a, K_places[i]));
+    Append(~lies_over, a_embed_dict[b_i]);
+  end for;
+  return lies_over;
+end function;
+
+intrinsic HeckeCharWeightFromWeight(K::Fld, F::Fld, k::SeqEnum[RngIntElt]) -> SeqEnum[Tup] 
+  {}
+  if IsParallel(k) then
+    r, s := Signature(K);
+    return [<0, 0> : _ in [1 .. r+s]];
+  else
+    k_0 := Max(k);
+    lies_over := OrderedPlacesOfCMField(K, F);
+    hc_wt := [<(k_0 - k[lies_over[i]]) / 2, (k_0 + k[lies_over[i]] - 2) / 2> : i in [1 .. #k]];
+    // if the weight is paritious, all the weight components should be integers
+    if IsParitious(k) then
+      hc_wt := [<Integers()!tup[1], Integers()!tup[2]> : tup in hc_wt];
+    end if;
+    return hc_wt;
+  end if;
+end intrinsic;
+
+intrinsic PossibleGrossencharsOfRelQuadExt(K, N, k_hmf, chi) -> List
+  {
+    inputs:
+      K - relative quadratic extension with base field F and 
+        discriminant dividing N
+      N - integral ideal of F 
+      k_hmf - weight of HMFs induced by the desired grossencharacters
+      chi - (finite order) Hecke character of F of modulus N
+    returns:
+      Grossencharacters of weight k and conductor N/Disc_(K/F) whose
+      restriction to AA_F is chi. 
+
+      If the weight is parallel, we remove characters which are invariant
+      under conjugation (see the ConjugateIdeal intrinsic) and only
+      return one character from each pair of conjugate ideals. 
+
+      The grossencharacters returned by this function corresponds to distinct CM 
+      modular forms after (automorphic) induction. 
   }
   ZK := Integers(K);
-  Disc := Discriminant(ZK);
+  rel_disc := Discriminant(ZK);
 
-  M := N/Disc;
-  assert IsIntegral(M);
-  M := Integers(AbsoluteField(K)) !! M;
-  H := HeckeCharacterGroup(M); // Is this correct or do I allow ramification at infinite places? I think I should allow ramification and and check some compatibility of the character with the weight [1,1]... 
-  G, m := RayClassGroup(M);
+  M := N / rel_disc;
+  require IsIntegral(M) : "The discriminant of K/F does not divide the level N";
+
+  M := Integers(AbsoluteField(K))!!M;
+  K_abs := AbsoluteField(K);
+  k := HeckeCharWeightFromWeight(K_abs, BaseField(K), k_hmf);
+  X := cHMFGrossencharsTorsor(K_abs, k, M);
+
+  if IsFiniteOrder(X) then
+    // we define grossencharacters over absolute fields
+    // so we need to pass in the base field
+    F := BaseField(K);
+    S := PrunedGrossencharsSet(X, F);
+  else
+    S := HMFGrossencharsTorsorSet(X);
+  end if;
 
   GF, mF := RayClassGroup(N, [1,2]);
-
-  ans := [];
-
-  for psi in Elements(H) do
-    if Norm(ZK !! Conductor(psi))*Disc eq N then
-      ok := false;
-      for g in Generators(G) do
-        if not psi( Integers(AbsoluteField(K)) !! ConjugateIdeal(K, m(g))  ) eq psi(m(g)) then
-          ok := true;
-          break g;
-        end if;
+  ans := [* *];
+  for psi in S do
+    N_psi := ZK!!(Conductor(psi));
+    if Norm(N_psi) * rel_disc eq N then
+      flag := true;
+      for g in Generators(GF) do
+        I := mF(g);
+        flag and:= StrongEquality(chi(I) * Norm(I)^(Max(k_hmf) - 1), psi(Integers(K_abs)!!(I))^-1 * QuadraticCharacter(I^-1, K));
       end for;
-      
-      okk := true;
-      if ok then
-        for g in Generators(GF) do
-          I := mF(g);
-          if not chi(I) eq psi(Integers(AbsoluteField(K)) !! I) * QuadraticCharacter(I, K) then
-            okk := false;
-          end if;
-        end for;
-        if okk then
-          Append(~ans, psi); 
-        end if;
+      if flag then
+        Append(~ans, psi);
       end if;
     end if;
   end for;
-  
-  if prune then
-    newlist := []; // New list of characters
-    pairlist := []; // List of paired characters, to be thrown away
-    
-    for i in [1 .. #ans] do // Loop over possible characters
-      psi := ans[i];
-      if i in pairlist then // This character was already paired
-        continue;
-      else 
-        Append(~newlist, i); // It wasn't in the list of paired characters, so add it to the new lsit of characters.
-      end if;
-      
-      for j in [1 .. #ans] do // Find the pair of psi
-        if j eq i then
-          continue; // Skip i
-        end if;
-        
-        psiconj := true; 
-        for g in Generators(G) do
-          if psi( Integers(AbsoluteField(K)) !! ConjugateIdeal(K, m(g)) ) eq ans[j](m(g)) then
-            continue;
-          else 
-            psiconj := false;
-          end if;
-        end for;
-        if psiconj then
-          Append(~pairlist, j);
-          break j;
-        end if;
-      end for;
-    end for;
-    assert #newlist eq #pairlist; // The characters should pair up since we removed conjugation-invariant ones.
-    ans := [ans[i] : i in newlist];
-  end if;
-  
   return ans;
 end intrinsic;
 
-intrinsic PossibleHeckeCharacters(
-  F::FldNum, 
-  N::RngOrdIdl,
-  chi::GrpHeckeElt
-  : 
-  prune := true
-  ) -> List
+intrinsic PossibleGrossenchars(Mk::ModFrmHilD) -> List
   {
-    Given a totally real field F, an ideal N of F, and a character chi of modulus N,
-    computes all finite order non-Galois-invariant Hecke characters of conductor dividing N
-    whose restriction is chi.
+    Given a space Mk of HMFs, computes the grossencharacters which induce
+    forms in Mk.
+
+    The induced forms will span the dihedral forms in Mk if Weight(Mk) is parallel
+    and the CM forms otherwise.
   }
   ans := [* *];
-  fields := QuadraticExtensionsWithConductor(N, [1,2]);
-  for K in fields do
-    ans := ans cat [* psi : psi in PossibleHeckeCharactersOfK(F, N, K, chi) *];
+  N := Level(Mk);
+  Ks := QuadraticExtensionsWithConductor(N, [1 .. Degree(BaseField(Mk))]);
+  k := Weight(Mk);
+  chi := Character(Mk);
+  for K in Ks do
+    ans cat:= [* psi : psi in PossibleGrossencharsOfRelQuadExt(K, N, k, chi) *];
   end for;
-
   return ans;
-end intrinsic;
-
-intrinsic PossibleHeckeCharacters(
-    Mk::ModFrmHilD
-    ) -> List
-{
-Given a totally real field F, an ideal N of F, and a character chi of modulus N, computes all finite order non-Galois-invariant Hecke characters of conductor dividing N whose restriction is chi.
-}
-    return PossibleHeckeCharacters(BaseField(Parent(Mk)), Level(Mk), Character(Mk));
 end intrinsic;
 
 //////////////////////////////// Computing spaces of dihedral forms
 
-intrinsic ThetaSeries(Mk::ModFrmHilD, psi::GrpHeckeElt) -> ModFrmHilDElt
+intrinsic ThetaSeries(Mk::ModFrmHilD, psi::HMFGrossenchar) -> ModFrmHilDElt
   {
     Given a totally real field F, a quadratic extension K of F,
     and a finite order Hecke character of K, compute the associated theta series.
@@ -203,24 +274,23 @@ intrinsic ThetaSeries(Mk::ModFrmHilD, psi::GrpHeckeElt) -> ModFrmHilDElt
   ZF := Integers(F);
   prec := Precision(M);
   K := NumberField(Order(Modulus(psi))); 
-  L := CyclotomicField(Order(psi));
   
   // We create an associative array indexed by prime ideals pp up to 
   // Precision(Parent(Mk)) and populate them with traces associated to psi.
   a_pps := AssociativeArray();
   for pp in PrimeIdeals(M) do
-  fact := Factorization(Integers(K) !! pp);
-  g := #fact;
-  d := InertiaDegree(pp);
-  a_pps[pp] := (g eq 2) // pp is split in K 
-    select psi(fact[1][1]) + psi(fact[2][1]) 
-    else // pp is inert or ramified in K
-    (
-    (fact[1][2] eq 1) select 0 else psi(fact[1][1])
-    );
+    fact := Factorization(Integers(K) !! pp);
+    g := #fact;
+    d := InertiaDegree(pp);
+    if g eq 2 then
+      a_pps[pp] := StrongAdd([* psi(fact[1][1])^-1, psi(fact[2][1])^-1 *]);
+    elif fact[1][2] ne 1 then
+      a_pps[pp] := psi(fact[1][1])^-1;
+    else
+      a_pps[pp] := 0;
+    end if;
   end for;
-
-  return CuspFormFromEigenvalues(Mk, a_pps : coeff_ring:=L);
+  return CuspFormFromEigenvalues(Mk, a_pps);
 end intrinsic;
 
 intrinsic ProbabilisticDihedralTest(f::ModFrmHilDElt) -> BoolElt

--- a/ModFrmHilD/HMFGrossenchar.m
+++ b/ModFrmHilD/HMFGrossenchar.m
@@ -1,0 +1,466 @@
+/******************************************************************************
+ * The HMFGrossenchar type represents a Hecke character over a specified
+ * base field of a given infinity-type and level. While the set of Grossencharacters
+ * of a given infinity-type and level is a torsor for the corresponding ray class group,
+ * there is no canonical way to identify the two sets. 
+ *
+ * As such, the HMFGrossencharsTorsor constructs an arbitrary element of this set,
+ * and its children objects are instances of HMFGrossenchar, each obtained by multiplying
+ * its parent's arbitrary element by a ray class character.
+ *
+ * Magma provides an implementation of Grossencharacters but it is restricted to
+ * algebraic finite-order characters, and we want neither of these restrictions. 
+ ******************************************************************************/
+
+declare type HMFGrossencharsTorsor [HMFGrossenchar];
+declare attributes HMFGrossencharsTorsor:
+  BaseField, // FldNum - A number field, say with r real places and s complex places
+  Weight, // SeqEnum[Tup[FldRatElt, FldRatElt]] - A sequence of the form
+          //   [<a_1, 0> ..., <a_r, 0>, <u_(r+1), v_(r+1)>, ..., <u_s, v_s>]
+          //   where r and s are as above and the a_i, u_i, and v_i are rational numbers.
+          //   Such a weight corresponds to the infinity-type 
+          //   \prod |x_i|^a_i * \prod z_j^u_j zbar_j^v_j,
+          //   ignoring the signs at the real places (which are handled elsewhere).
+  FiniteModulus, // RngOrdIdl - The finite modulus 
+  InfiniteModulus, // SeqEnum[RngOrdInt] - The infinite modulus 
+  ClassGroup, ClassMap, // GpAb, Map -  cached output of ClassGroup(X`BaseField),
+  ClassGroupReps, // SeqEnum[Tup[GpAbElt, RngOrdIdl]] - A sequence consisting of 
+                     // generators for the class group and corresponding ideal 
+                     // representatives. We do this because the algorithm for computing
+                     // generators is nondeterministic.
+  MarkedDrchChar, // GrpDrchNFElt - A character psi of the ray residue ring of modulus Modulus(X)
+                   // such that psi * chi_inf (the infinity-type associated to the given weight)
+                   // is trivial on units (i.e. is a character on principal ideals). 
+  MarkedCharClassRepEvals, // Assoc: 
+  IsNonempty; // bool: true if there are Grossencharacters of this weight and level
+
+declare attributes HMFGrossenchar:
+  Parent, // HMFGrossencharsTorsor
+  RayClassChar; // GrpHeckeElt 
+
+//////////////////////////////// HMFGrossencharsTorsor ////////////////////////////////
+
+//////////////////////////////// HMFGrossencharsTorsor constructors
+
+intrinsic cHMFGrossencharsTorsor(
+    K::FldNum,
+    k::SeqEnum,
+    N_f::RngOrdIdl :
+    N_oo:=[1 .. #RealPlaces(K)]
+   ) -> HMFGrossencharsTorsor
+  {
+    inputs:
+      K - A Galois number field
+      k - A weight, as described above
+      N_f - A finite modulus 
+      N_oo - An infinite modulus
+    returns:
+      A type representing the set of Grossencharacters over K
+      with weight k, finite modulus N_f, and infinite modulus N_oo
+
+    Basic constructor 
+  }
+  X := New(HMFGrossencharsTorsor);
+  X`BaseField := K;
+  X`Weight := k;
+  X`FiniteModulus := N_f;
+  X`InfiniteModulus := N_oo;
+  G, X`ClassMap := ClassGroup(X`BaseField);
+  require IsDiagonal(RelationMatrix(G)) : "There should be no cross-relations\
+      between the generators of the ray class group";
+
+  X`ClassGroupReps := [<G.i, X`ClassMap(G.i)> : i in [1 .. #Generators(G)]];
+  X`ClassGroup := G;
+
+  if IsNonempty(X) then
+    SetMarkedCharClassRepEvals(X);
+  end if;
+  return X;
+end intrinsic;
+
+intrinsic HMFGrossencharsTorsorSet(X::HMFGrossencharsTorsor) -> SetEnum
+  {
+    Returns the set of HMFGrossenchar objects of this torsor. 
+    This set will either be empty or have cardinality equal
+    to that of HeckeCharacterGroup(Modulus(X)).
+  }
+  N_f, N_oo := Modulus(X); 
+  H := HeckeCharacterGroup(N_f, N_oo);
+  out := {};
+  if IsNonempty(X) then
+    for chi in Elements(H) do
+      Include(~out, cHMFGrossenchar(X, chi));
+    end for;
+  end if;
+  
+  if not IsNonempty(X) then
+    require #out eq 0 : "Something has gone wrong - if the torsor is empty,\
+      the set should be empty";
+  else
+    require #out eq #H : "Something has gone wrong, this set should be in 1-1 correspondence\
+      with characters of the corresponding ray class group.";
+  end if;
+  return out;
+end intrinsic;
+
+intrinsic HMFGrossencharsTorsorSet(K::FldNum, k::SeqEnum[Tup], N::RngOrdIdl) -> SetEnum
+  {}
+  X := cHMFGrossencharsTorsor(K, k, N);
+  return HMFGrossencharsTorsorSet(X);
+end intrinsic;
+
+//////////////////////////////// HMFGrossencharsTorsor helpers
+
+intrinsic EvaluateNoncompactInfinityType(X::HMFGrossencharsTorsor, x::FldElt) -> FldElt, FldElt
+  {
+    inputs:
+      X - a torsor of HMFs of a given field K, level N, weight k
+      x - An element of the field K
+    returns:
+      If the weight k is
+      [<a_1, b_1>, ..., <a_r, b_r>, <u_(r+1), v_(r+1)>, ..., <u_s, v_s>],
+      evaluates the "non-sign" part of the infinity-type on x,
+      i.e. the map x -> \prod |x_i|^a_i * \prod z_j^u_j zbar_j^v_j,
+      where the first product is over the embeddings under real places
+      and the latter is over the embeddings under imaginary places.
+
+      This is the evaluation of the infinity-type with the \prod sgn(x_i)^b_i 
+      (over the embeddings under real places) omitted. We deal with the 
+      sign part elsewhere.
+  }
+  K := X`BaseField;
+  require Parent(x) eq K : "x must be an element of the base field of X";
+
+  places := InfinitePlaces(K);
+  r, s := Signature(K);
+
+  // If this is a finite order character, then the weight
+  // part of the infinity type is 1. 
+  if IsFiniteOrder(X) then
+    return Rationals()!1;
+  end if;
+
+  K_gal := (IsNormal(K)) select K else SplittingField(K);
+  auts := AutsOfKReppingEmbeddingsOfF(K, K_gal);
+  gal_conjs_of_x := [aut(x) : aut in auts];
+  
+  // If the character is algebraic, then the infinity type looks like
+  // a product of integral powers. Otherwise, our output will live in 
+  // a field extension with some square roots. 
+  if IsAlgebraic(X) then
+    L := K_gal;
+  else
+    R<z> := PolynomialRing(K);
+    polys := [];
+    for i->y in gal_conjs_of_x do
+      append_sqrt := false;
+      if (i le r + s) and not IsIntegral(X`Weight[i][1]) then
+        append_sqrt := true;
+      elif (i gt r + s) and not IsIntegral(X`Weight[i - s][2]) then
+        append_sqrt := true;
+      end if;
+
+      if append_sqrt then
+        poly := x^2-y;
+        if IsIrreducible(x^2-y) then
+          Append(~polys, poly);
+        end if;
+      end if;
+    end for;
+    L := (#polys eq 0) select K else AbsoluteField(ext<K | polys>);
+  end if;
+
+  out := L!1;
+  for i->y in gal_conjs_of_x do
+    if i le r then
+      u_i := X`Weight[i][1];
+      out *:= (L!y)^(u_i);
+    elif i le (r + s) then
+      u_i := X`Weight[i][1];
+      out *:= (L!y)^(u_i);
+    else
+      v_i := X`Weight[i - s][2];
+      out *:= (L!y)^(v_i);
+    end if;
+  end for;
+
+  return out;
+end intrinsic;
+
+intrinsic EvaluateNoncompactInfinityType(X::HMFGrossencharsTorsor, x::RngElt) -> FldElt
+  {}
+  K := NumberField(Parent(x));
+  return  EvaluateNoncompactInfinityType(X, K!x);
+end intrinsic;
+
+intrinsic IsNonempty(X::HMFGrossencharsTorsor) -> BoolElt, GrpDrchNFElt
+  {
+    Suppose X has modulus m (note that this is both the finite level N
+    and the ramified real places), base field F, and non-compact
+    infinity-type chi_nc. 
+
+    Returns true, psi if there is a Dirichlet character with modulus m
+    such that psi(eps) * chi_nc(eps) = 1 for all units eps of F,
+    and assigns X`MarkedDrchChar := psi
+
+    Otherwise, returns false, _.
+
+    If such a psi exists, psi * chi_nc is a character on
+    principal ideals, and we can extend it to a character on ideals.
+  }
+  if not assigned X`IsNonempty then
+    mod_fin, mod_inf := Modulus(X);
+    Dv := DirichletGroup(mod_fin, mod_inf);
+    if IsFiniteOrder(X) then
+      X`IsNonempty := true;
+      X`MarkedDrchChar := Dv.0;
+    else
+      D, D_map := RayResidueRing(mod_fin, mod_inf);
+      D_gens := SetToSequence(Generators(D));
+      // largest possible order of an element in D
+      max_D_order := LCM([Order(gen) : gen in D_gens]);
+
+      // The values of the infinity-type on units and the values of possible
+      // Dirichlet characters psi all lie in Q(zeta_m). 
+      //
+      // Because m can be quite large, we avoid constructing Q(zeta_m). 
+      // Instead, we perform the computation to find psi over the complex
+      // numbers. 
+      d := LargestRootOfUnity(SplittingField(X`BaseField));
+      m := LCM(max_D_order, d);
+      L := CyclotomicField(d);
+      rou_dict := AssociativeArray();
+      for j in [0 .. d - 1] do
+        rou_dict[L.1^j] := j;
+      end for;
+      units_gens := UnitsGenerators(X`BaseField : exclude_torsion:=false);
+      unit_preimg_seqs := [Eltseq(eps @@ D_map) : eps in units_gens];
+      M := [[unit_preimg_seqs[j][i] * ExactQuotient(m, Order(D_gens[i])) : j in [1 .. #units_gens]] : i in [1 .. #D_gens]];
+      char_vector := func<i, n, x | [(j eq i) select x else 0 : j in [1 .. n]]>;
+      M cat:= [char_vector(j, #units_gens, m) : j in [1 .. #units_gens]];
+      M := Matrix(M);
+      v := [ExactQuotient(m, d) * rou_dict[StrongCoerce(L, EvaluateNoncompactInfinityType(X, eps))] : eps in units_gens];
+      v := Vector(v);
+      X`IsNonempty, u := IsConsistent(M, v);
+      if X`IsNonempty then
+        if #D eq 1 then
+          X`MarkedDrchChar := AssociatedPrimitiveCharacter(Dv.0);
+        else
+          Dv_gens := Generators(Dv);
+          // we invert because we want the product of the Dirichlet character
+          // and the infinity type to be 1.
+          D_gens := [gen : gen in D_gens | Order(gen) ne 1];
+          Dv_gens := [gen : gen in SetToSequence(Dv_gens) | Order(gen) ne 1];
+          assert #Dv_gens eq #D_gens;
+          psi := (&*[Dv.j^(u[j]) : j in [1 .. #D_gens]])^-1;
+          X`MarkedDrchChar := AssociatedPrimitiveCharacter(psi);
+          for eps in units_gens do
+            require IsOne(StrongMultiply(
+                  [* EvaluateNoncompactInfinityType(X, eps), X`MarkedDrchChar(eps) *]
+                  )) : "The marked character isn't the inverse of the infinity type";
+          end for;
+        end if;
+      end if;
+    end if;
+  end if;
+
+  if X`IsNonempty then
+    require assigned X`MarkedDrchChar : "If X is nonempty them the marked\
+      Dirichlet character must be assigned";
+    return true, X`MarkedDrchChar;
+  else
+    return false, _;
+  end if;
+end intrinsic;
+
+//////////////////////////////// HMFGrossencharsTorsor fundamental intrinsics
+
+intrinsic Print(X::HMFGrossencharsTorsor, level::MonStgElt)
+  {}
+  if level in ["Default", "Minimal", "Maximal"] then
+    printf "Grossencharacters over the %o\n", X`BaseField;
+    printf "with weight %o ", X`Weight;
+    printf "and finite modulus%o\n", IdealOneLine(X`FiniteModulus);
+  elif level eq "Magma" then
+    error "not implemented yet!";
+  else
+    error "not a valid printing level.";
+  end if;
+end intrinsic;
+
+intrinsic 'eq'(X_1::HMFGrossencharsTorsor, X_2::HMFGrossencharsTorsor) -> BoolElt
+  {}
+  if X_1`BaseField eq X_2`BaseField and 
+    X_1`Weight eq X_2`Weight and
+    X_1`FiniteModulus eq X_2`FiniteModulus then
+    return true;
+  else
+    return false;
+  end if;
+end intrinsic;
+
+//////////////////////////////// HMFGrossencharsTorsor attribute access
+
+intrinsic Modulus(X::HMFGrossencharsTorsor) -> RngOrdIdl, SeqEnum[RngIntElt]
+  {}
+  return X`FiniteModulus, X`InfiniteModulus;
+end intrinsic;
+
+intrinsic IsFiniteOrder(X::HMFGrossencharsTorsor) -> BoolElt
+  {}
+  for tup in X`Weight do
+    if not IsZero(tup[1]) then
+      return false;
+    end if;
+  end for;
+  return true;
+end intrinsic;
+
+intrinsic IsAlgebraic(X::HMFGrossencharsTorsor) -> BoolElt
+  {}
+  for tup in X`Weight do
+    if not (IsIntegral(tup[1]) and IsIntegral(tup[2])) then
+      return false;
+    end if;
+  end for;
+  return true;
+end intrinsic;
+
+//////////////////////////////// HMFGrossencharsTorsor evaluation
+
+function MaxPowerDividingD(x, d)
+  // returns the largest divisor of d such that x is a dth root
+  divisors := Divisors(d);
+  for t in Reverse(divisors) do
+    if IsPower(x, t) then
+      return t;
+    end if;
+  end for;
+  assert 0 eq 1; // Something has gone wrong, any element should be a first root
+end function;
+
+intrinsic SetMarkedCharClassRepEvals(X::HMFGrossencharsTorsor)
+  {
+    Define the evaluation of a marked element of the set of
+    Grossencharacters of this weight on representatives of generators
+    of the ray class group.
+  }
+  if not assigned X`MarkedCharClassRepEvals then
+    X`MarkedCharClassRepEvals := AssociativeArray();
+
+    polys := [];
+    inf_evals := [];
+    L := RationalsAsNumberField();
+    reps := [];
+    for tup in X`ClassGroupReps do
+      gen, rep := Explode(tup);
+      d := Order(gen);
+
+      b, x := IsPrincipal(rep^d);
+      require b : "Something has gone wrong, rep^d should be a principal ideal";
+
+      a := EvaluateNoncompactInfinityType(X, x) * X`MarkedDrchChar(x);
+
+      t := MaxPowerDividingD(L!a, d);
+      L := RadicalExtension(L, Integers()!(d/t), L!a);
+      X`MarkedCharClassRepEvals[rep] := Root(L!a, d)^-1;
+      Append(~reps, rep);
+    end for;
+    for rep in reps do
+      X`MarkedCharClassRepEvals[rep] := L!X`MarkedCharClassRepEvals[rep];
+    end for;
+  end if;
+end intrinsic;
+
+//////////////////////////////// HMFGrossenchar constructors
+
+intrinsic cHMFGrossenchar(X::HMFGrossencharsTorsor, psi::GrpHeckeElt) -> HMFGrossenchar
+  {}
+  // check that psi is the right whatnots
+  chi := New(HMFGrossenchar);
+  chi`Parent := X;
+  require Modulus(psi) eq Modulus(X) : "The given ray class character does not have\
+      the same modulus as the given parent object";
+  chi`RayClassChar := psi;
+  return chi;
+end intrinsic;
+
+//////////////////////////////// HMFGrossenchar fundamental intrinsics
+
+intrinsic Parent(chi::HMFGrossenchar) -> HMFGrossencharsTorsor
+  {}
+  return chi`Parent;
+end intrinsic;
+
+intrinsic 'eq'(chi_1::HMFGrossenchar, chi_2::HMFGrossenchar) -> BoolElt
+  {}
+  if (chi_1`Parent eq chi_2`Parent) and (chi_1`RayClassChar eq chi_2`RayClassChar) then
+    return true;
+  else
+    return false;
+  end if;
+end intrinsic;
+
+intrinsic Print(chi::HMFGrossenchar, level::MonStgElt)
+  {}
+  if level in ["Default", "Minimal", "Maximal"] then
+    printf "Grossencharacter element associated to the ray class character %o\nin the set of ", chi`RayClassChar;
+    print Parent(chi);
+  elif level eq "Magma" then
+    error "not implemented yet!";
+  else
+    error "not a valid printing level.";
+  end if;
+end intrinsic;
+
+intrinsic '@'(I::RngOrdIdl, chi::HMFGrossenchar) -> FldElt
+  {}
+  X := Parent(chi);
+  b, x := IsPrincipal(I);
+  if b then
+    marked_char_on_J := Rationals()!1;
+  else
+    I_CG := I @@ X`ClassMap; 
+    J := X`ClassMap(I_CG);
+
+    // We choose a generator for IJ^-1. 
+    c, x := IsPrincipal(I * J^-1);
+    require c : "Something has gone wrong, I * J^-1 should be principal";
+    vals := X`ClassGroupReps;
+    g := I @@ X`ClassMap;
+    g_factzn_exps := Eltseq(g);
+    require &+[g_factzn_exps[i] * vals[i][1] : i in [1 .. #vals]] eq g : "Something has gone wrong,\ 
+      Eltseq(g) should give a factorization of g in terms of the generators of the class group."; 
+    marked_char_on_J := &*[X`MarkedCharClassRepEvals[vals[i][2]]^(g_factzn_exps[i]) : i in [1 .. #vals]];
+  end if;
+
+  return StrongMultiply([*
+      chi`RayClassChar(I),
+      marked_char_on_J,
+      EvaluateNoncompactInfinityType(X, x)^-1,
+      X`MarkedDrchChar(X`BaseField!x)^-1 
+      *]);
+end intrinsic;
+
+//////////////////////////////// HMFGrossenchar attribute access
+
+intrinsic Conductor(chi::HMFGrossenchar) -> RngOrdIdl
+  {}
+  X := Parent(chi);
+  return Conductor(X`MarkedDrchChar * DirichletRestriction(chi`RayClassChar)^-1);
+end intrinsic;
+
+intrinsic Modulus(chi::HMFGrossenchar) -> RngOrdIdl
+  {}
+  return Modulus(Parent(chi));
+end intrinsic;
+
+intrinsic IsAlgebraic(chi::HMFGrossenchar) -> RngOrdIdl
+  {}
+  return IsAlgebraic(Parent(chi));
+end intrinsic;
+
+intrinsic IsFiniteOrder(chi::HMFGrossenchar) -> RngOrdIdl
+  {}
+  return IsFiniteOrder(Parent(chi));
+end intrinsic;

--- a/ModFrmHilD/HMFGrossenchar.m
+++ b/ModFrmHilD/HMFGrossenchar.m
@@ -476,3 +476,39 @@ intrinsic IsFiniteOrder(chi::HMFGrossenchar) -> RngOrdIdl
   {}
   return IsFiniteOrder(Parent(chi));
 end intrinsic;
+
+intrinsic IsPrimitive(chi::HMFGrossenchar) -> BoolElt
+  {}
+  N_f, N_oo := Conductor(chi);
+  M_f, M_oo := Modulus(chi);
+  return N_f eq M_f and N_oo eq M_oo;
+end intrinsic;
+
+intrinsic AssociatedPrimitiveCharacter(chi::HMFGrossenchar) -> HMFGrossenchar
+  {}
+  if IsPrimitive(chi) then
+    return chi;
+  end if;
+
+  M_f, M_oo := Modulus(chi);
+  N_f, N_oo := Conductor(chi);
+  X := Parent(chi);
+  Y := cHMFGrossencharsTorsor(X`BaseField, X`Weight, N_f : N_oo:=N_oo);
+  S := HMFGrossencharsTorsorSet(Y);
+  reps := RayClassGroupReps(X);
+  chi_on_reps := [* chi(rep) : rep in reps *];
+  for psi in S do
+    flag := true;
+    for i in [1 .. #reps] do
+      rep := reps[i];
+      if not StrongEquality(psi(rep), chi_on_reps[i]) then 
+        flag := false;
+        break;
+      end if;
+    end for;
+    if flag then
+      return psi;
+    end if;
+  end for;
+  require false : "Something is wrong!";
+end intrinsic;

--- a/ModFrmHilD/HMFGrossenchar.m
+++ b/ModFrmHilD/HMFGrossenchar.m
@@ -28,6 +28,9 @@ declare attributes HMFGrossencharsTorsor:
                      // generators for the class group and corresponding ideal 
                      // representatives. We do this because the algorithm for computing
                      // generators is nondeterministic.
+  RayClassGroupReps, // SeqEnum[Tup[GpAbElt, RngOrdIdl]] - The above, but for the 
+                     // ray class group of modulus that of X. We can test on these ideals
+                     // to distinguish different elements of X.
   MarkedDrchChar, // GrpDrchNFElt - A character psi of the ray residue ring of modulus Modulus(X)
                    // such that psi * chi_inf (the infinity-type associated to the given weight)
                    // is trivial on units (i.e. is a character on principal ideals). 
@@ -324,6 +327,15 @@ intrinsic IsAlgebraic(X::HMFGrossencharsTorsor) -> BoolElt
     end if;
   end for;
   return true;
+end intrinsic;
+
+intrinsic RayClassGroupReps(X::HMFGrossencharsTorsor) -> SeqEnum[RngOrdIdl]
+  {}
+  if not assigned X`RayClassGroupReps then
+    G, mp:= RayClassGroup(X`FiniteModulus, X`InfiniteModulus); 
+    X`RayClassGroupReps := [mp(gen) : gen in Generators(G)];
+  end if;
+  return X`RayClassGroupReps;
 end intrinsic;
 
 //////////////////////////////// HMFGrossencharsTorsor evaluation

--- a/ModFrmHilD/spec
+++ b/ModFrmHilD/spec
@@ -9,6 +9,7 @@
   Export.m
   FldExt.m
   Formatting.m
+  HMFGrossenchar.m
   IdlCoeffEltCoeffConversion.m
   GradedPoly.m
   GradedRing.m

--- a/Tests/dihedral.m
+++ b/Tests/dihedral.m
@@ -1,16 +1,52 @@
+/***************************************************
+* There should be (h_K - h_K[2])/2 Grossencharacters
+* coming from K/F if F has narrow class number 1 and 
+* we require the conductor of the induced HMFs to be 
+* a prime ideal.
+***************************************************/
+
 for d in [5, 13] do
   F := QuadraticField(d);  
-
-  for P in PrimesUpTo(500, F) do
-    for K in QuadraticExtensionsWithConductor(P, [1,2]) do
-      HF := HeckeCharacterGroup(P, [1,2]);
-      AH := 0;
-      for chi in Elements(HF) do
-        AH := AH + #PossibleHeckeCharactersOfK(F, P, K, chi);
+  if NarrowClassNumber(F) eq 1 then
+    for P in PrimesUpTo(500, F) do
+      for K in QuadraticExtensionsWithConductor(P, [1,2]) do
+        k := [1,1];
+        HF := HeckeCharacterGroup(P, [1,2]);
+        AH := 0;
+        for chi in Elements(HF) do
+          AH := AH + #PossibleGrossencharsOfRelQuadExt(K, P, k, chi);
+        end for;
+        G := ClassGroup(AbsoluteField(K));
+        AM := (#G - #quo<G | 2*G>)/2; 
+        assert AH eq AM;
       end for;
-      G := ClassGroup(AbsoluteField(K));
-      AM := (#G - #quo<G | 2*G>)/2; 
-      assert AH eq AM;
     end for;
-  end for;
+  end if;
 end for;
+
+/***************************************************
+* Tests computation of a dihedral form in the weight 
+* [1,3] case and ensures it agrees with the form 
+* obtained via Hecke stability.
+***************************************************/
+
+F := QuadraticField(5);
+ZF := Integers(F);
+N := Factorization(41*ZF)[1][1];
+k := [1,3];
+GRng := GradedRingOfHMFs(F, 150);
+H := HeckeCharacterGroup(N, [1,2]);
+chi := H.1;
+Mk := HMFSpace(GRng, N, k, chi);
+psis := PossibleGrossenchars(Mk);
+
+// there should only be one Grossencharacter
+assert #psis eq 1;
+
+Dk := DihedralBasis(Mk);
+assert #Dk eq 1;
+f := Dk[1];
+g := CuspFormBasis(Mk)[1];
+
+// f and g should be the same (up to scaling)
+assert #LinearDependence([f, g]) eq 1;

--- a/Tests/dihedral_basis.m
+++ b/Tests/dihedral_basis.m
@@ -1,3 +1,10 @@
+/***************************************************
+ * There is exactly one [1,1] dihedral form of level N.
+ * We check that it's in the cusp space (computed via
+ * Hecke stability). We then check that the forms
+ * are included into the dihedral space of level 2*N.
+***************************************************/
+
 F := QuadraticField(5);
 ZF := Integers(F);
 N := ideal<ZF | 241, 2*ZF.2 + 137>;
@@ -27,3 +34,20 @@ assert #LinearDependence(Dk2_old) eq 0;
 assert #LinearDependence(Sk2 cat Dk2_old) eq #Dk2_old;
 // the size of Dk1 should be the twice that of Dk2_old
 assert #Dk2_old eq 2 * #Dk1;
+
+/***************************************************
+ * We verify that the Moy-Specter form is not dihedral
+***************************************************/
+
+F := QuadraticField(5);
+ZF := Integers(F);
+prec := 550;
+M := GradedRingOfHMFs(F, prec);
+N := 14*ZF;
+H := HeckeCharacterGroup(N, [1,2]);
+H_prim := HeckeCharacterGroup(7*ZF, [1,2]);
+chi_prim := (H_prim).1;
+chi := H.1;
+M15chi := HMFSpace(M, N, [1,5], chi);
+D15chi := DihedralBasis(M15chi);
+assert #D15chi eq 0;

--- a/Tests/grossenchar.m
+++ b/Tests/grossenchar.m
@@ -83,3 +83,35 @@ K := NumberField(x^3 - 2);
 ZK := Integers(K);
 k := [<0,0>, <0,0>, <0,0>];
 N := Factorization(5*ZK)[1][1];
+
+/**************************************************
+* Test computation of associated primitive character
+**************************************************/
+
+F := QuadraticField(5);
+M := 108*Integers(F);
+H := HeckeCharacterGroup(M, [1,2]);
+psi := H.1;
+assert not IsPrimitive(psi);
+psi_prim := AssociatedPrimitiveCharacter(psi);
+N_psi_f, N_psi_oo := Conductor(psi);
+
+X := cHMFGrossencharsTorsor(F, [<0,0>, <0,0>], M : N_oo:=[1,2]);
+reps := RayClassGroupReps(X);
+S := HMFGrossencharsTorsorSet(X);
+for eta in S do
+  if eta`RayClassChar eq psi then
+    chi := eta;
+    break;
+  end if;
+end for;
+
+assert [* chi(rep) : rep in reps *] cmpeq [* psi(rep) : rep in reps *];
+chi_prim := AssociatedPrimitiveCharacter(chi);
+N_chi_f, N_chi_oo := Conductor(chi);
+assert N_chi_f eq N_psi_f;
+assert N_chi_oo eq N_psi_oo;
+
+G, mp := RayClassGroup(N_psi_f, N_psi_oo);
+new_reps := [mp(gen) : gen in Generators(G)];
+assert [chi_prim(rep) : rep in new_reps] cmpeq [psi(rep) : rep in new_reps];

--- a/Tests/grossenchar.m
+++ b/Tests/grossenchar.m
@@ -1,0 +1,85 @@
+/**************************************************
+* Test for finite-order characters
+* Note that because of the torsor implementation,
+* if psith is a ray class character, the psi-th element 
+* of the torsor may not be psi. 
+**************************************************/
+procedure test_finite_order(K, k, N)
+  // K - a number field
+  // k - a weight
+  // N - a finite conductor
+  X := cHMFGrossencharsTorsor(K, k, N);
+  S := HMFGrossencharsTorsorSet(X);
+  
+  assert IsNonempty(X);
+  assert assigned X`MarkedDrchChar;
+
+  r, s := Signature(K);
+  G, mp := RayClassGroup(N, [1 .. r]);
+  reps := [mp(G.i) : i in [1 .. #Generators(G)]];
+  
+  MIN_COUNT := 4;
+  H := HeckeCharacterGroup(N, [1 .. r]);
+  // the order of S should be that of the corresponding ray class group
+  assert #H eq #S;
+
+  trials := Min(MIN_COUNT, #H);
+
+  for _ in [1 .. trials] do
+    psi := Random(H);
+    flag := false;
+    for chi in S do
+      if &and[chi(rep) cmpeq psi(rep) : rep in reps] then
+        if flag eq false then
+          flag := true;
+        else
+          // there should be only one chi in S which agrees with psi
+          assert 0 eq 1;
+        end if;
+        // Conductors should be the same
+        assert Conductor(chi) eq Conductor(psi);
+      end if;
+    end for;
+    // There should be some chi in the torsor
+    // agreeing with psi
+    assert flag;
+  end for;
+end procedure;
+
+// n = 2, h = 1, totally real, finite order
+K := QuadraticField(5);
+ZK := Integers(K);
+k := [<0,0>, <0,0>];
+N := 48*ZK;
+test_finite_order(K, k, N);
+
+N := Factorization(41*ZK)[2][1];
+test_finite_order(K, k, N);
+
+// n = 2, h = 4, totally real, finite order
+K := QuadraticField(39);
+ZK := Integers(K);
+k := [<0,0>, <0,0>];
+N := 23*ZK;
+test_finite_order(K, k, N);
+
+// n = 4, h = 1, totally imaginary, finite order
+K := CyclotomicField(8);
+ZK := Integers(K);
+k := [<0,0>, <0,0>];
+N := 11*ZK;
+test_finite_order(K, k, N);
+
+// n = 3, h = 1, finite order
+R<x> := PolynomialRing(Rationals());
+K := NumberField(x^3 - x^2 - 2*x + 1);
+ZK := Integers(K);
+k := [<0,0>, <0,0>, <0,0>];
+N := 7*ZK;
+test_finite_order(K, k, N);
+
+// n = 3, h = 1, non-Galois, mixed signature, finite order
+K := NumberField(x^3 - 2);
+ZK := Integers(K);
+k := [<0,0>, <0,0>, <0,0>];
+N := Factorization(5*ZK)[1][1];


### PR DESCRIPTION
- Implement Grossencharacters in Magma. Magma does have some implementation already, but this one is better for us because it carefully handles embeddings/coefficient fields and also supports non-algebraic Hecke characters
- Adapt the CM/dihedral forms code to work with the new Grossencharacters, thereby introducing support for CM forms in nonparallel weight