### PR TITLE
move basis check outside the Intersection code

### DIFF
--- a/ModFrmHilD/Creation/HeckeStability.m
+++ b/ModFrmHilD/Creation/HeckeStability.m
@@ -22,7 +22,7 @@ intrinsic HeckeStableSubspace(
     for _ in [1 .. #V] do
         vprintf HilbertModularForms:  "Current dim = %o\n", dimprev;
         TpVprev := [HeckeOperator(g, pp) : g in Vprev];
-        Vnew := Intersection(Vprev, TpVprev);
+        Vnew := Intersection(Vprev, Basis(TpVprev));
         dimnew := #Vnew;
 
         vprintf HilbertModularForms: "New dim = %o\n", dimnew;

--- a/ModFrmHilD/LinearAlgebra.m
+++ b/ModFrmHilD/LinearAlgebra.m
@@ -125,11 +125,12 @@ end intrinsic;
 
 intrinsic Intersection(V::SeqEnum[ModFrmHilDElt], W::SeqEnum[ModFrmHilDElt]) -> SeqEnum[ModFrmHilDElt]
   {}
+  // assumes that V and W are actually bases, but doesn't check this 
+  // to avoid a slowdown. TODO abhijitm can probably handle better
   if #V eq 0 or #W eq 0 then
     return [];
   end if;
-  V := Basis(V);
-  W := Basis(W);
+
   lindep := LinearDependence(V cat W);
   intersection := [];
   for v in lindep do


### PR DESCRIPTION
This was causing a regression which should now be fixed. Should probably add some sort of check inside the intersection logic in the future. 