### PR TITLE
incremental changes

### DIFF
--- a/ModFrmHilD/Creation/HeckeStability.m
+++ b/ModFrmHilD/Creation/HeckeStability.m
@@ -53,7 +53,8 @@ intrinsic HeckeStabilityCuspBasis(
     :
     prove:=true,
     stable_only:=false,
-    smallest_prime:=true
+    smallest_prime:=true,
+    SaveAndLoad:=false
     ) -> SeqEnum[ModFrmHilDElt]
     {
       Compute the space Mk using the Hecke stability method.
@@ -64,6 +65,13 @@ intrinsic HeckeStabilityCuspBasis(
           If true, we return the Hecke stable subspace we find without 
           raising it to a dth power to ensure that the forms we found 
           are genuinely holomorphic.
+        - The optional parameter smallest_prime is true or false.
+          If true, we use the Hecke operator associated to the prime of smallest
+          norm in this field. If false, we use the prime of smallest norm which is
+          coprime to the level. The former is only guaranteed to find newforms.
+        - The optional parameter SaveandLoad is true or false.
+          If true, we attempt to SaveAndLoad any cusp form bases we need during the 
+          computation.
     }
 
     M := Parent(Mk);
@@ -109,7 +117,7 @@ intrinsic HeckeStabilityCuspBasis(
     //Load space of Cusp forms of weight [k1 + eis_k, ..., kn + eis_k], level N, and trivial character
     vprintf HilbertModularForms: "Computing basis of cusp forms of weight %o, level %o\n", [k[i] + eis_k : i in [1 .. n]], N;
     Mkl := HMFSpace(M, N, [k[i] + eis_k : i in [1 .. n]]);
-    Bkl := CuspFormBasis(Mkl);
+    Bkl := CuspFormBasis(Mkl : SaveAndLoad:=SaveAndLoad);
     
     vprintf HilbertModularForms: "Size of basis is %o.\n", #Bkl;
 
@@ -153,7 +161,7 @@ intrinsic HeckeStabilityCuspBasis(
     d := Order(chi);
     Mk_dth_power := HMFSpace(M, N, [d*k[i] : i in [1 .. n]]);
     Bmod := Basis(Mk_dth_power);
-    Bcusp := CuspFormBasis(Mk_dth_power);
+    Bcusp := CuspFormBasis(Mk_dth_power : SaveAndLoad:=SaveAndLoad);
 
     require #Bcusp eq CuspDimension(Mk_dth_power): "Need to increase precision to compute this space";
 

--- a/ModFrmHilD/Elements.m
+++ b/ModFrmHilD/Elements.m
@@ -234,6 +234,15 @@ intrinsic ChangeCoefficientRing(f::ModFrmHilDElt, R::Rng) -> ModFrmHilDElt
   return HMFSumComponents(Parent(f), components);
 end intrinsic;
 
+intrinsic CanChangeRing(f::ModFrmHilDElt, R::Rng) -> BoolElt, ModFrmHilDElt
+  {}
+  try
+    return true, ChangeCoefficientRing(f, R);
+  catch e
+    return false, _;
+  end try;
+end intrinsic;
+
 intrinsic IsCoercible(Mk::ModFrmHilD, f::.) -> BoolElt, .
 {}
     if Type(f) eq RngIntElt then

--- a/ModFrmHilD/HMFGrossenchar.m
+++ b/ModFrmHilD/HMFGrossenchar.m
@@ -228,6 +228,9 @@ intrinsic IsNonempty(X::HMFGrossencharsTorsor) -> BoolElt, GrpDrchNFElt
     if IsFiniteOrder(X) then
       X`IsNonempty := true;
       X`MarkedDrchChar := Dv.0;
+    elif &and[IsOne(EvaluateNoncompactInfinityType(X, eps)) : eps in UnitsGenerators(X`BaseField : exclude_torsion:=false)] then
+      X`IsNonempty := true;
+      X`MarkedDrchChar := Dv.0;
     else
       K := X`BaseField;
       E := (IsGalois(K)) select K else SplittingField(K);

--- a/ModFrmHilD/Hecke.m
+++ b/ModFrmHilD/Hecke.m
@@ -88,7 +88,7 @@ end intrinsic;
 //
 // For most applications, the ModFrmHil/ or Trace.m code should be used. 
 
-intrinsic Eigenbasis(M::ModFrmHilD, basis::SeqEnum[ModFrmHilDElt] : P := 60) -> SeqEnum[ModFrmHilDElt]
+intrinsic Eigenbasis(M::ModFrmHilD, basis::SeqEnum[ModFrmHilDElt] : P := 60, coprime_only:=true) -> SeqEnum[ModFrmHilDElt]
   {
     inputs:
       M: A space of forms on which the Hecke algebra acts by
@@ -106,7 +106,8 @@ intrinsic Eigenbasis(M::ModFrmHilD, basis::SeqEnum[ModFrmHilDElt] : P := 60) -> 
   ZF := Integers(F);
   hecke_matrices := [];
 
-  for pp in PrimesUpTo(P, F : coprime_to:=N) do
+  primes := (coprime_only) select PrimesUpTo(P, F : coprime_to:=N) else PrimesUpTo(P, F);
+  for pp in primes do
     Append(~hecke_matrices, HeckeMatrix(basis, pp));
   end for;
 

--- a/ModFrmHilD/SaveAndLoad.m
+++ b/ModFrmHilD/SaveAndLoad.m
@@ -202,8 +202,8 @@ intrinsic LoadOrBuildAndSave(
     inputs:
       Mk - space of HMFs
       builder - intrinsic which is used to build
-        the basis if it is not saved
-      suffix - string suffix where this basis should
+        the basis if it is not saved.
+        suffix - string suffix where this basis should
         be saved/loaded from
       save_dir - directory where precomputed results
         are saved
@@ -227,7 +227,11 @@ intrinsic LoadOrBuildAndSave(
   // loaded is false if the file was not saved or if
   // the precision of the stored basis wasn't high enough
   if not loaded then
-    basis := builder(Mk);
+    if builder eq HeckeStabilityCuspBasis then
+      basis := HeckeStabilityCuspBasis(Mk : SaveAndLoad:=true);
+    else
+      basis := builder(Mk);
+    end if;
     SaveBasis(loadfile_name, basis);
   end if;
   return basis;


### PR DESCRIPTION
- load precomputed higher weight spaces during during HeckeStability
- function to check if a form can be coerced into a smaller coefficient ring
- avoid the expensive check to test if the Grossencharacter torsor is nonempty if the infinity type is trivial on units
- add an option to allow primes dividing the level in Eigenbasis (useful when applying to a subspace of newforms)