### PR TITLE
replace TotallyPositiveUnits with TotallyPositiveUnitsGroup

### DIFF
--- a/ModFrmHilD/Creation/Igusa.m
+++ b/ModFrmHilD/Creation/Igusa.m
@@ -97,7 +97,7 @@ intrinsic SiegelEisensteinPullback(M::ModFrmHilDGRng, k::SeqEnum[RngIntElt]) -> 
   if not IsTotallyPositive(factors) then //just in case factors is negative
     factors:=-factors;
   end if;
-  G, unitmp := TotallyPositiveUnits(M);
+  G, unitmp := TotallyPositiveUnitsGroup(M);
 
   Mkplus := HMFSpace(M, k);
   // Dealing with unit characters

--- a/ModFrmHilD/FldExt.m
+++ b/ModFrmHilD/FldExt.m
@@ -1,6 +1,6 @@
 // save fundamental unit
 declare attributes FldAlg:
-  TotallyPositiveUnits,
+  TotallyPositiveUnitsGroup,
   TotallyPositiveUnitsMap,
   TotallyPositiveUnitsGenerators,
   TotallyPositiveUnitsGeneratorsOrients,
@@ -63,10 +63,10 @@ intrinsic Signature(a::RngOrdElt) -> SeqEnum
   return Signature(FieldOfFractions(R)!a);
 end intrinsic;
 
-intrinsic TotallyPositiveUnits(F::FldAlg) -> GrpAb, Map
+intrinsic TotallyPositiveUnitsGroup(F::FldAlg) -> GrpAb, Map
   {return the group of totally positive units of the base as an abstract group and the map from abstract totally positive unit group into F^\times_>0}
 
-  if not assigned F`TotallyPositiveUnits or not assigned F`TotallyPositiveUnitsMap then
+  if not assigned F`TotallyPositiveUnitsGroup or not assigned F`TotallyPositiveUnitsMap then
     U, mp := UnitGroup(F);
     // Stupid function, the isomorphism mu_2 -> ZZ/2*ZZ
     hiota := function(u);
@@ -81,11 +81,11 @@ intrinsic TotallyPositiveUnits(F::FldAlg) -> GrpAb, Map
     UZd := AbelianGroup([2 : i in [1..Degree(F)]]);
     phi := hom<U -> UZd | [[hiota(Sign(Evaluate(mp(U.i), v))) : v in RealPlaces(F)] : i in [1..#Generators(U)]]>;
     K := Kernel(phi);
-    F`TotallyPositiveUnits := K;
+    F`TotallyPositiveUnitsGroup := K;
     F`TotallyPositiveUnitsMap := mp;
   end if;
 
-  return F`TotallyPositiveUnits, F`TotallyPositiveUnitsMap;
+  return F`TotallyPositiveUnitsGroup, F`TotallyPositiveUnitsMap;
 end intrinsic;
 
 intrinsic FundamentalUnit(F::FldNum) -> FldElt
@@ -117,7 +117,7 @@ intrinsic TotallyPositiveUnitsGenerators(F::FldNum) -> SeqEnum[RngOrdElt]
   end if;
 
   if not assigned F`TotallyPositiveUnitsGenerators then
-    PU, mPU := TotallyPositiveUnits(F);
+    PU, mPU := TotallyPositiveUnitsGroup(F);
     tpugs_unorient := [Integers(F)!mPU(gen) : gen in Generators(PU)];
 
     v := InfinitePlaces(F)[1];
@@ -129,9 +129,9 @@ intrinsic TotallyPositiveUnitsGenerators(F::FldNum) -> SeqEnum[RngOrdElt]
     // consistent with the existing behavior of FundamentalUnitTotPos
     //
     // We keep track of which generators are inverted with respect to the 
-    // Generators(F`TotallyPositiveUnits) because we need to solve the word
+    // Generators(F`TotallyPositiveUnitsGroup) because we need to solve the word
     // problem in the unit generators code and it solves it there with respect
-    // to Generators(F`TotallyPositiveUnits).
+    // to Generators(F`TotallyPositiveUnitsGroup).
     for eps in tpugs_unorient do
       if Evaluate(eps, v) lt 1 then
         Append(~F`TotallyPositiveUnitsGenerators, eps);
@@ -148,7 +148,7 @@ end intrinsic;
 intrinsic TotallyPositiveUnitsGeneratorsOrients(F::FldNum) -> SeqEnum
   {
     Returns a sequence whose ith entry e is such that the 
-    ith element of SetToSequence(Generators(TotallyPositiveUnits)) is the
+    ith element of SetToSequence(Generators(TotallyPositiveUnitsGroup)) is the
     ith element of F`TotallyPositiveUnitsGenerators raised to the eth power.
 
     Here, e will either be 1 or -1. 

--- a/ModFrmHilD/GradedRing.m
+++ b/ModFrmHilD/GradedRing.m
@@ -194,9 +194,9 @@ intrinsic UnitGroupMap(M::ModFrmHilDGRng) -> Any
   return M`UnitGroupMap;
 end intrinsic;
 
-intrinsic TotallyPositiveUnits(M::ModFrmHilDGRng) -> GrpAb, Map
+intrinsic TotallyPositiveUnitsGroup(M::ModFrmHilDGRng) -> GrpAb, Map
   {return the group of totally positive units of the base as an abstract group and the map from abstract totally positive unit group into F^\times_>0}
-  return TotallyPositiveUnits(BaseField(M));
+  return TotallyPositiveUnitsGroup(BaseField(M));
 end intrinsic;
 
 intrinsic Places(M::ModFrmHilDGRng) -> Any
@@ -326,7 +326,7 @@ intrinsic GradedRingOfHMFs(F::FldNum, prec::RngIntElt) -> ModFrmHilDGRng
 
   M`UnitGroup := U;
   M`UnitGroupMap := mU;
-  _, _ := TotallyPositiveUnits(F); // it caches it
+  _, _ := TotallyPositiveUnitsGroup(F); // it caches it
   // maybe we should make good choices for narrow class group reps
   // i.e. generators of small trace?
   // TODO: see above 2 lines

--- a/ModFrmHilD/Space.m
+++ b/ModFrmHilD/Space.m
@@ -14,7 +14,7 @@ declare attributes ModFrmHilD:
   Basis, // = EisensteinBasis cat CuspFormBasis SeqEnum[ModFrmHilDElt]
   Character, // GrpHeckeElt, JV: why aren't we using Dirichlet?
   UnitCharacters, // Assoc: unit[bb] = omega
-                 // Type(omega) = GrpCharUnitTotElt: TotallyPositiveUnits(Parent(Parent)) -> CoefficientRing
+                 // Type(omega) = GrpCharUnitTotElt: TotallyPositiveUnitsGroup(Parent(Parent)) -> CoefficientRing
   EisensteinBasis, // SeqEnum[ModFrmHilDElt]
   CuspFormBasis, // SeqEnum[ModFrmHilDElt]
   EllipticBasis, // SeqEnum[ModFrmHilDElt]

--- a/ModFrmHilD/UnitChar.m
+++ b/ModFrmHilD/UnitChar.m
@@ -20,7 +20,7 @@ intrinsic Evaluate(omega::GrpCharUnitTotElt, x::RngElt) -> RngElt
   else
     b, c := IsDefined(omega`cachedvalues, F!x);
     if not b then
-      U, mU := TotallyPositiveUnits(F);
+      U, mU := TotallyPositiveUnitsGroup(F);
       orients := TotallyPositiveUnitsGeneratorsOrients(F);
       vals := omega`vals;
       c := &*[vals[i]^(a[i]*orients[i]) : i in [1..#vals]] where a := Eltseq(U!(x@@mU));
@@ -86,7 +86,7 @@ intrinsic TrivialUnitCharacter(F::FldAlg) -> GrpCharUnitTotElt
   {Create the trivial unit character on the totally positive unit group
    of the ring of integers of F.}
 
- return UnitCharacter(F, [1: i in [1..#Generators(TotallyPositiveUnits(F))]]);
+ return UnitCharacter(F, [1: i in [1..#Generators(TotallyPositiveUnitsGroup(F))]]);
 end intrinsic;
 
 intrinsic WeightUnitCharacter(F::FldAlg, k::SeqEnum[RngIntElt]) -> GrpCharUnitTotElt


### PR DESCRIPTION
The name `TotallyPositiveUnits` conflicts with an existing attribute in Magma, so we rename ours to avoid issues.