### PR TITLE
feat(examples): D49 level (2) defect-to-q-expansion bridge (infinity cusp)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ a CI runner live in `examples/slow/` and are skipped by CI; run them manually wi
 | Modular curve X0(11) | X0(11) model is an elliptic curve of conductor 11 | `modular_curve_X0_11.m` | CI |
 | Igusa invariants | Igusa invariants for Q(sqrt 12) and Q(sqrt 21) | `igusa_invariants.m` | CI |
 | Hilbert modular threefolds | cyclic cubic field Q(zeta_7 + zeta_7^-1), with trace-formula dimensions, products, Hecke translates in weights 8 and 10, and syzygy-algorithm equations for the threefold map | `cyclic_cubic_threefold.m` | CI |
+| Hilbert modular threefolds | D=49 level (2) weight 4 defect-to-q-expansion bridge for the arXiv:2501.15719 positive Kodaira-dimension row | `d49_level2_defect_bridge.m` | CI |
 | D=8 | Q(sqrt 8) canonical ring vs Hirzebruch | `canonical_ring_Qsqrt2.m` | pending (plan 4b: witness map) |
 | D=13 | Q(sqrt 13) canonical ring vs van der Geer-Zagier | `canonical_ring_Qsqrt13.m` | pending (plan 4b: witness map) |
 | D=5 | Q(sqrt 5) canonical ring vs Hirzebruch/Gundlach | `canonical_ring_Qsqrt5.m` | pending (plan 4b: witness map) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ a CI runner live in `examples/slow/` and are skipped by CI; run them manually wi
 | Modular curve X0(11) | X0(11) model is an elliptic curve of conductor 11 | `modular_curve_X0_11.m` | CI |
 | Igusa invariants | Igusa invariants for Q(sqrt 12) and Q(sqrt 21) | `igusa_invariants.m` | CI |
 | Hilbert modular threefolds | cyclic cubic field Q(zeta_7 + zeta_7^-1), with trace-formula dimensions, products, Hecke translates in weights 8 and 10, and syzygy-algorithm equations for the threefold map | `cyclic_cubic_threefold.m` | CI |
-| Hilbert modular threefolds | D=49 level (2) weight 4 defect-to-q-expansion bridge for the arXiv:2501.15719 positive Kodaira-dimension row | `d49_level2_defect_bridge.m` | CI |
+| Hilbert modular threefolds | D=49 level (2) weight 4 defect-to-q-expansion bridge (infinity-cusp half, 2 of 4 defect conditions; second cusp is follow-up) for the arXiv:2501.15719 positive Kodaira-dimension row | `d49_level2_defect_bridge.m` | CI |
 | D=8 | Q(sqrt 8) canonical ring vs Hirzebruch | `canonical_ring_Qsqrt2.m` | pending (plan 4b: witness map) |
 | D=13 | Q(sqrt 13) canonical ring vs van der Geer-Zagier | `canonical_ring_Qsqrt13.m` | pending (plan 4b: witness map) |
 | D=5 | Q(sqrt 5) canonical ring vs Hirzebruch/Gundlach | `canonical_ring_Qsqrt5.m` | pending (plan 4b: witness map) |

--- a/examples/d49_level2_defect_bridge.m
+++ b/examples/d49_level2_defect_bridge.m
@@ -1,0 +1,139 @@
+// D=49, level (2), weight 4 defect-to-q-expansion bridge.
+//
+// This is a companion to the positive Kodaira-dimension row
+// for K = Q(zeta_7)^+ and level (2) in arXiv:2501.15719.  It computes
+// the q=2 cusp-defect coefficient ideals via the defect algorithm, maps
+// the infinity-cusp conditions to ModFrmHilD coefficient keys, and checks
+// the corresponding rank on a weight-4 q-expansion basis.
+//
+// Runs in CI (about 1 minute); run it directly with:
+//   magma -b filename:=examples/d49_level2_defect_bridge.m exitsignal:='' run_tests.m
+//
+// In an attached Magma session, set BuildBasis := false before loading this
+// file to skip the slow basis computation and only print/check the index bridge.
+
+if not assigned BuildBasis then
+  BuildBasis := true;
+elif Type(BuildBasis) eq MonStgElt then
+  BuildBasis := not (BuildBasis in {"false", "False", "0", ""});
+end if;
+
+function CompareIdealLabels(a, b)
+  la := LMFDBLabel(a);
+  lb := LMFDBLabel(b);
+  if la lt lb then
+    return -1;
+  elif la eq lb then
+    return 0;
+  else
+    return 1;
+  end if;
+end function;
+
+function IdealLabelOrZero(I)
+  if IsZero(I) then
+    return "0";
+  end if;
+  return LMFDBLabel(I);
+end function;
+
+function DefectCoefficientIdealsForPrincipalCusp(F, q)
+  ZF := Integers(F);
+  dd := Different(ZF);
+  codiff := dd^-1;
+
+  // Positive trace < q implies every real embedding is in (0, q), so this
+  // hypercube contains all elements needed by Algorithm defect for M = O_F.
+  Mbox := GradedRingOfHMFs(F, 10);
+  RR := RealField();
+  candidates := ElementsInAHyperCube(Mbox, codiff,
+      [RR | 0 : i in [1..Degree(F)]], [RR | q : i in [1..Degree(F)]]);
+  ts := [t : t in candidates | t ne 0 and IsTotallyPositive(t) and Trace(t) lt q];
+
+  ideals := {};
+  for t in ts do
+    I := ideal<ZF | t*dd>;
+    for J in Divisors(I) do
+      if IsNarrowlyPrincipal(I * J^-1) then
+        Include(~ideals, J);
+      end if;
+    end for;
+  end for;
+
+  return Sort(SetToSequence(ideals), CompareIdealLabels), ts;
+end function;
+
+function InfinityDefectIndexData(M, ideals)
+  F := BaseField(M);
+  ZF := Integers(F);
+  zero := 0*ZF;
+  data := [* *];
+
+  bb0 := NarrowClassGroupReps(M)[1];
+  Append(~data, <bb0, F!0, zero, [0 : i in [1..Degree(F)]]>);
+
+  for J in ideals do
+    bb := IdealToNarrowClassRep(M, J);
+    nu := IdealToRep(M, J);
+    p := M`FunDomainReps[bb][nu];
+    exp := M`FunDomainRepsOfPrec[bb][p][nu];
+    assert Norm(J) le Precision(M);
+    Append(~data, <bb, nu, J, exp>);
+  end for;
+
+  return data;
+end function;
+
+function InfinityDefectMatrix(forms, data)
+  return Matrix([[Coefficient(f, item[1], item[2]) : f in forms] : item in data]);
+end function;
+
+procedure CheckD49Level2Weight4DefectBridge()
+  Q := Rationals();
+  R<x> := PolynomialRing(Q);
+  F<w> := NumberField(x^3 - x^2 - 2*x + 1);
+  ZF := Integers(F);
+  assert Discriminant(ZF) eq 49;
+
+  q := 2;
+  defect_ideals, trace_terms := DefectCoefficientIdealsForPrincipalCusp(F, q);
+  assert #defect_ideals + 1 eq 2;
+  assert defect_ideals eq [1*ZF];
+
+  printf "Trace<%o codifferent representatives: %o\n", q, [F!t : t in trace_terms];
+  printf "Nonzero defect coefficient ideals: %o\n", [LMFDBLabel(J) : J in defect_ideals];
+
+  M := GradedRingOfHMFs(F, 100);
+  N := 2*ZF;
+  Mk := HMFSpace(M, N, [4,4,4]);
+
+  // arXiv:2501.15719 Table positive-kod uses dim M_4 = 6 and total defect 4.
+  assert NumberOfCusps(Mk) eq 2;
+  assert EisensteinDimension(Mk) eq 2;
+  assert CuspDimension(Mk : version := "builtin") eq 4;
+  assert Dimension(Mk) eq 6;
+
+  data := InfinityDefectIndexData(M, defect_ideals);
+  printf "Infinity-cusp ModFrmHilD indices:\n";
+  for item in data do
+    bb, nu, J, exp := Explode(item);
+    printf "  bb=%o ideal=%o nu=%o exponent=%o\n", LMFDBLabel(bb), IdealLabelOrZero(J), nu, exp;
+  end for;
+
+  if BuildBasis then
+    printf "Building basis for D=49 level (2) weight 4 at precision %o\n", Precision(M);
+    time B := Basis(Mk);
+    assert #B eq Dimension(Mk);
+
+    mat := InfinityDefectMatrix(B, data);
+    printf "Infinity-cusp defect matrix has %o rows, %o columns, rank %o\n",
+        Nrows(mat), Ncols(mat), Rank(mat);
+    assert Nrows(mat) eq 2;
+    assert Ncols(mat) eq 6;
+    assert Rank(mat) eq 2;
+  else
+    printf "Skipping basis and matrix check because BuildBasis=false\n";
+  end if;
+end procedure;
+
+CheckD49Level2Weight4DefectBridge();


### PR DESCRIPTION
Adds a worked example that bridges the Hilbert modular threefold **defect** data to ModFrmHilD q-expansion coefficients, for the positive Kodaira-dimension row of arXiv:2501.15719: `K = Q(zeta_7)^+` (cyclic cubic field of discriminant 49), level `(2)`, parallel weight 4.

The example runs the principal-cusp defect algorithm at `q = 2` (nonzero defect coefficient ideal `[1.1]`, so `delta(2) = 2`), maps those infinity-cusp conditions to the `(bb, nu)` coefficient keys used by `ModFrmHilDElt`, verifies the q-expansion precision covers every index, and checks that the resulting 2x6 vanishing matrix on the weight-4 basis has full rank 2.

## Changes

- `examples/d49_level2_defect_bridge.m`: the example, plus a `BuildBasis` toggle so an attached session can skip the basis build and only print/check the index bridge.
- `examples/README.md`: one manifest row.

## Verification

Runs green via `magma -b filename:=examples/d49_level2_defect_bridge.m exitsignal:='' run_tests.m` in roughly 70s, and runs in CI on its own matrix runner (CI fans out one file per runner). It asserts `NumberOfCusps=2`, `EisensteinDimension=2`, `CuspDimension(builtin)=4`, `Dimension=6`, and defect-matrix rank 2.

## Scope and follow-up

This is the **infinity-cusp half** of the D=49 level (2) witness: 2 of the 4 defect conditions from the arXiv table row. Completing the full row needs the second cusp via a Fricke/Atkin-Lehner (cusp-change) q-expansion bridge, which is left as follow-up. Stacked on `feat/examples-test-wiring` so the diff is only the new example.
