### PR TITLE
fix(canonical-ring): use builtin dimensions for cubic (degree>2) fields

### DIFF
--- a/ModFrmHilD/CanonicalRing/CanonicalRing.m
+++ b/ModFrmHilD/CanonicalRing/CanonicalRing.m
@@ -696,6 +696,14 @@ end function;
 intrinsic ComputePrecisionFromHilbertSeries(NN::RngOrdIdl, B::RngIntElt) -> RngIntElt
   {Compute the number of q-expansion coefficients needed from the coefficients of the Hilbert series}
   F := NumberField(Order(NN));
+  if Degree(F) ne 2 then
+    // The trace-formula Hilbert series is only validated for real quadratic
+    // fields and is non-integral for degree != 2. The weight-B coefficient is
+    // exactly dim M_B, so take it from the builtin dimension backend instead.
+    M := GradedRingOfHMFs(F, 1);
+    MB := HMFSpace(M, NN, [B : i in [1..Degree(F)]]);
+    return 10*Dimension(MB) + 10;
+  end if;
   H := HilbertSeries(F,NN);
   Pow<T> := PowerSeriesRing(Rationals(), B+1);
   return 10*Integers()!Coefficient(Pow!H, B) + 10;

--- a/ModFrmHilD/Space.m
+++ b/ModFrmHilD/Space.m
@@ -423,6 +423,15 @@ intrinsic CuspDimension(Mk::ModFrmHilD : version:="trace") -> RngIntElt
     version := "builtin";
   end if;
 
+  // The trace formula (ModFrmHilD/Trace) is only validated for real quadratic
+  // fields. For degree != 2 its elliptic term can leave an uncancelled 1/(order)
+  // from higher-order elliptic points, returning non-integer "dimensions"
+  // (e.g. 36/7 for F = Q(zeta_7)^+ at level (2), weight 4). Use the builtin
+  // backend there until the general totally-real formula is implemented.
+  if Degree(BaseField(Mk)) ne 2 then
+    version := "builtin";
+  end if;
+
   if not assigned Mk`CuspDimension then
     k := Weight(Mk);
     if version eq "builtin" then

--- a/Tests/cubic_trace_dimension.m
+++ b/Tests/cubic_trace_dimension.m
@@ -1,0 +1,60 @@
+// test-time: ~40s
+//
+// Regression test: cubic trace-formula dimensions must be integers and agree
+// with the builtin backend.
+//
+// The Eichler-Selberg trace formula in ModFrmHilD/Trace/Trace.m was only ever
+// validated for real quadratic fields (see Tests/dimensions.m, Tests/traces.m,
+// and pos_elts_of_trace.m which asserts Degree(F) eq 2). For the cyclic cubic
+// field F = Q(zeta_7)^+ (disc 49) it returns non-integer "dimensions": the CM
+// extension Q(zeta_7)/F contributes elliptic points of order 7 whose 1/7 weight
+// (via ClassNumberOverUnitIndex, from the 14th roots of unity) is not cancelled.
+//
+// Concretely HilbertSeries(F, 2*ZF) has coefficients 20/7 at weight 2 and 36/7
+// at weight 4, so on the broken backend:
+//   * CuspDimension(: version := "trace") throws (Integers()!<rational>), and
+//   * ComputePrecisionFromHilbertSeries(2*ZF, k) throws for k in {2,4}.
+// The builtin backend gives the correct dim M_2 = 2 and dim M_4 = 6.
+//
+// The fix routes degree != 2 through the builtin dimension, so the trace path
+// no longer throws and agrees with builtin.
+
+Qx<x> := PolynomialRing(Rationals());
+F := NumberField(x^3 - x^2 - 2*x + 1); // Q(zeta_7)^+, disc 49
+ZF := Integers(F);
+NN := 2*ZF;
+
+assert Degree(F) eq 3;
+assert Discriminant(ZF) eq 49;
+assert NarrowClassNumber(F) eq 1; // rules out class-group-character effects
+
+R := GradedRingOfHMFs(F, 1);
+
+// Known-correct dimensions (Magma builtin, cross-checked against arXiv:2501.15719
+// Table tab:positive-kod for the D=49 level-(2) target).
+expected_cusp := AssociativeArray();
+expected_cusp[2] := 0;
+expected_cusp[4] := 4;
+expected_total := AssociativeArray();
+expected_total[2] := 2;
+expected_total[4] := 6;
+
+for k in [2, 4] do
+    Mk := HMFSpace(R, NN, [k, k, k]);
+
+    // Default CuspDimension path uses version := "trace"; on the broken backend
+    // this throws for the cubic field. After the fix it must return the builtin value.
+    cusp_trace := CuspDimension(Mk : version := "trace");
+    delete Mk`CuspDimension;
+    cusp_builtin := CuspDimension(Mk : version := "builtin");
+    assert cusp_trace eq cusp_builtin;
+    assert cusp_trace eq expected_cusp[k];
+
+    delete Mk`CuspDimension;
+    assert Dimension(Mk) eq expected_total[k];
+
+    // Precision helper must return an integer consistent with dim M_k.
+    prec := ComputePrecisionFromHilbertSeries(NN, k);
+    assert Type(prec) eq RngIntElt;
+    assert prec eq 10 * expected_total[k] + 10;
+end for;


### PR DESCRIPTION
## Problem

The Eichler-Selberg trace formula in `ModFrmHilD/Trace` was only ever validated
for real quadratic fields (every trace/dimension test uses `QuadraticField`, and
`Tests/pos_elts_of_trace.m` asserts `Degree(F) eq 2`). For totally real fields of
degree > 2 its elliptic term leaves an uncancelled `1/(order)` from higher-order
elliptic points, so it returns non-integer "dimensions". Concretely, over
`F = Q(zeta_7)^+` (disc 49) at level `(2)`:

```
HilbertSeries(F, 2*ZF): dim M_2 -> 20/7, dim M_4 -> 36/7   (builtin: 2 and 6)
```

`Q(zeta_7)^+` has order-7 elliptic points because the CM extension `Q(zeta_7)`
carries the 14th roots of unity; that `1/7` (via `ClassNumberOverUnitIndex`) is
never cancelled. This threw `Integers()!<rational>` in
`CuspDimension(version:="trace")` and `ComputePrecisionFromHilbertSeries`,
blocking the canonical-ring pipeline for cubic threefolds.

## Fix

Route `Degree(F) != 2` through Magma's builtin dimension backend, mirroring the
existing non-parallel and non-ambient fallbacks. This is correct because
`HilbertCuspForms` is an independent, validated computation.

- `ModFrmHilD/Space.m`: `CuspDimension` falls back to `builtin` for degree != 2.
- `ModFrmHilD/CanonicalRing/CanonicalRing.m`: `ComputePrecisionFromHilbertSeries`
  reads `dim M_B` from the builtin dimension instead of the fractional trace
  series for degree != 2.
- `Tests/cubic_trace_dimension.m`: regression test for the D=49 level-(2) case.

## Verification

- New test fails on the base branch (`Illegal coercion` at `Space.m:434`) and
  passes with the fix (12.8s).
- `ComputePrecisionFromHilbertSeries(2*ZF, 4) = 70 = 10*dim(M_4)+10`, `dim M_4 = 6`.
- `ConstructGeneratorsAndRelations` now reaches generator/relation construction
  (generators `[<2,2>, <4,3>]`) instead of crashing in dimension setup.
- No regression on quadratics: `Tests/dimensions.m` (27s) and
  `Tests/hilbert_series.m` (9s) still pass.

## Scope

This is a rigorous workaround: for degree > 2 it uses the trusted builtin
backend. The correct general totally-real trace/dimension formula (fixing the
elliptic term, or the Thomas-Vasquez cubic Hilbert series) is a separate,
larger piece of work and is tracked outside this PR.
