### PR TITLE
ci: prime magma cache once before the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
 
   pull_request_target:
 
+env:
+  # Increase this value to reset cache when MAGMA_URL changes.
+  MAGMA_CACHE_NUMBER: 2.29-8
+
 jobs:
 
   matrix:
@@ -70,6 +74,40 @@ jobs:
 
 
 
+  prime-magma:
+    runs-on: ubuntu-latest
+    needs: has_access
+    if: needs.has_access.outputs.has_access == 'true'
+    steps:
+      - name: Cache magma
+        uses: actions/cache@v3
+        id: magmacache
+        with:
+          path: |
+            ./magma
+          key:
+            ${{ env.MAGMA_CACHE_NUMBER }}
+
+      - name: Install magma
+        env:
+          MAGMA_URL: ${{ secrets.MAGMA_URL }}
+        shell: bash
+        if: steps.magmacache.outputs.cache-hit != 'true'
+        run: |
+          for i in 1 2 3; do
+            wget "$MAGMA_URL" -O magma.tar.gz --quiet && break
+            echo "download attempt $i failed; retrying"; sleep 15
+          done
+          tar xf magma.tar.gz
+          test -x ./magma/magma   # fail loudly so a bad download never poisons the cache
+
+      - name: Create dummy network device
+        shell: bash
+        run: |
+          sudo ip link add dumdum type dummy
+          sudo ifconfig dumdum hw ether `./magma/magma -d | grep "Valid MAC addresses" -A1 | tail -n1`
+          echo | ./magma/magma
+
   printjob:
     name: print event
     runs-on: ubuntu-latest
@@ -86,7 +124,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Run tests
-    needs: [has_access, matrix]
+    needs: [has_access, matrix, prime-magma]
     if: needs.has_access.outputs.has_access == 'true'
 
     strategy:
@@ -126,14 +164,11 @@ jobs:
       - name: Cache magma
         uses: actions/cache@v3
         id: magmacache
-        env:
-          # Increase this value to reset cache when MAGMA_URL changes
-          CACHE_NUMBER: 2.29-6
         with:
           path: |
             ./magma
           key:
-            ${{ env.CACHE_NUMBER }}
+            ${{ env.MAGMA_CACHE_NUMBER }}
 
       - name: Install magma
         env:


### PR DESCRIPTION
## What

Extracts the CI cache-priming fix into a standalone, library-change-free PR so it can merge on its own, without waiting on the library/data commits bundled in #505.

A new serial `prime-magma` job downloads Magma once (with retries and an executable guard), runs it once to validate the MAC-locked license, and populates the cache. The `test` matrix now depends on it, so the ~100 parallel cold downloads that were overwhelming `MAGMA_URL` are replaced by a single download.

## Changes (`.github/workflows/tests.yml` only)

- New `prime-magma` job; `test` matrix now `needs: [has_access, matrix, prime-magma]`.
- Hoist the cache number to a single top-level `env: MAGMA_CACHE_NUMBER` (bumped to `2.29-8`) so the prime and test jobs cannot drift out of sync (a one-sided bump would otherwise reintroduce the download stampede).
- Validate that magma actually runs in the prime job (dummy-MAC device + `echo | ./magma/magma`) before the cache is saved, so a runnable-but-unlicensed or corrupt binary cannot poison the shared cache.

## Notes

- CI-only: no library or data changes.
- Combines the CI change from #505 (@assaferan) with the follow-up fix in 77394d2.
- `tests.yml` validated as well-formed YAML.
