### PR TITLE
fix(canonical-ring): evaluate polynomial at the supplied forms

### DIFF
--- a/ModFrmHilD/CanonicalRing/CanonicalRing.m
+++ b/ModFrmHilD/CanonicalRing/CanonicalRing.m
@@ -120,7 +120,7 @@ intrinsic Evaluate(F::RngMPolElt, v::List) -> ModFrmHilDElt
 {Given a multivariate polynomial `F` with `n` variables, and a list `v`, return
 `F(v[1], ..., v[n])`. No attempt is made to check whether this is well-defined.}
     coeffs, mons := CoefficientsAndMonomials(F);
-    eviled_mons := EvaluateMonomials([* F *], mons);
+    eviled_mons := EvaluateMonomials(v, mons);
     return &+[coeffs[i] * eviled_mons[i] : i in [1..#eviled_mons]];
 end intrinsic;
 

--- a/Tests/canonical_ring_evaluate.m
+++ b/Tests/canonical_ring_evaluate.m
@@ -1,0 +1,34 @@
+// Regression: Evaluate(F, v) for v::List and v::SeqEnum must substitute the
+// supplied forms into F, not the polynomial F itself
+// (bug was EvaluateMonomials([* F *], mons) instead of EvaluateMonomials(v, mons)).
+printf "Testing Evaluate of a polynomial at HMFs (List/SeqEnum overloads)...";
+
+F<nu> := QuadraticField(5);
+ZF := Integers(F);
+prec := 60;
+R := GradedRingOfHMFs(F, prec);
+
+// Two independent forms in the same weight-[6,6] space.
+M6 := HMFSpace(R, [6, 6]);
+B6 := Basis(M6);
+assert #B6 ge 2;
+f := B6[1];
+g := B6[2];
+
+// Weighted polynomial ring in x, y matching the weights of f, g.
+P := ConstructWeightedPolynomialRing([* f, g *]);
+x := P.1;
+y := P.2;
+
+// List overload: the result must use f and g, hence equal f + g.
+// On the buggy code this substitutes into [* F *] and returns a polynomial,
+// so the comparison against the HMF f + g errors.
+assert Evaluate(x + y, [* f, g *]) eq f + g;
+
+// SeqEnum overload delegates to the List overload, so it must behave the same.
+assert Evaluate(x + y, [f, g]) eq f + g;
+
+// Coefficients and variable order must be honoured (f, g are independent).
+assert Evaluate(2*x + y, [* f, g *]) eq 2*f + g;
+
+return true;


### PR DESCRIPTION
## What

Fixes a pre-existing bug in `Evaluate(F::RngMPolElt, v::List)` (`ModFrmHilD/CanonicalRing/CanonicalRing.m`): it passed `[* F *]` (the polynomial itself) to `EvaluateMonomials` as the generator list instead of the caller's forms `v`, so it ignored the inputs entirely and evaluated `F` at itself. The `Evaluate(F, v::SeqEnum[ModFrmHilDElt])` overload delegates here and inherited the same bug.

The one-line fix passes `v` to `EvaluateMonomials`.

## Test

`Tests/canonical_ring_evaluate.m` (Q(sqrt 5), ~1s) evaluates `x + y` and `2*x + y` at two independent weight-[6,6] forms through both the List and SeqEnum overloads and checks the result equals the direct combination. Verified failing on the base (crashes with `Bad argument types: ModFrmHilDEltComp, RngMPolElt`) and passing after the fix. Adjacent suites `canonicalring_Qsqrt5` and `graded_ring` still pass.

## Notes

- Pre-existing since 2022; the only in-package caller was the SeqEnum-to-List delegation, so nothing relied on the old behavior.
