### PR TITLE
fix(canonical-ring): deterministic weighted-ring variable ordering

### DIFF
--- a/ModFrmHilD/CanonicalRing/CanonicalRing.m
+++ b/ModFrmHilD/CanonicalRing/CanonicalRing.m
@@ -14,7 +14,8 @@
 // Output: R = Weighted polynomial ring
 intrinsic ConstructWeightedPolynomialRing(Gens::Assoc)-> RngMPol
   {Return a weighted polynomial ring with #Gens[k] generators of degree k, for k in the keys of Gens}
-  GenWeights := &cat[[w : j in [1..#g]] : w->g in Gens];
+  sordidKeys := Sort(Setseq(Keys(Gens)));
+  GenWeights := &cat[[w : j in [1..#Gens[w]]] : w in sordidKeys];
   R := PolynomialRing(Rationals(), GenWeights);
   return R;
 end intrinsic;
@@ -79,7 +80,8 @@ intrinsic EvaluateMonomials(Gens::Assoc, MonomialGens::SeqEnum[RngMPolElt]) -> S
   {For a given set of HMF this produces all multiples with weight k}
 
   // this uses the same order as ConstructWeightedPolynomialRing
-  GenList := Sum([* SequenceToList(g): w->g in Gens*] : empty := [* *]);
+  sordidKeys := Sort(Setseq(Keys(Gens)));
+  GenList := Sum([* SequenceToList(Gens[w]): w in sordidKeys*] : empty := [* *]);
   return EvaluateMonomials(GenList, MonomialGens);
 end intrinsic;
 
@@ -571,7 +573,15 @@ intrinsic MakeScheme(Gens::Assoc, Relations::Assoc)-> Any
   R := ConstructWeightedPolynomialRing(Gens);
   PolynomialList := [];
   for i in Keys(Relations) do
-    PolynomialList cat:= RelationstoPolynomials(R,Relations[i],i);
+    rels := RelationstoPolynomials(R,Relations[i],i);
+    // Adding verification that the relations are satisfied
+    // This is in order to verify we did not mess up the ordering.
+    for rel in rels do
+      coeffs, mons := CoefficientsAndMonomials(rel);
+      evaluated_mons := EvaluateMonomials(Gens, mons);
+      assert &+[coeffs[i]*evaluated_mons[i] : i in [1..#coeffs]] eq 0;
+    end for;
+    PolynomialList cat:= rels;
   end for;
 
   P := ProjectiveSpace(R);

--- a/ModFrmHilD/Components.m
+++ b/ModFrmHilD/Components.m
@@ -591,6 +591,11 @@ intrinsic 'eq'(f :: ModFrmHilDEltComp, g :: ModFrmHilDEltComp) -> BoolElt
            and Expansion(f) eq Expansion(g);
 end intrinsic;
 
+intrinsic 'eq'(f::ModFrmHilDEltComp, c::RngElt) -> BoolElt
+  {compare f against a scalar c}
+  return Expansion(f) eq c;
+end intrinsic;
+
 intrinsic '+'(f :: ModFrmHilDEltComp, g :: ModFrmHilDEltComp) -> ModFrmHilDEltComp
 {}
     require Space(f) eq Space(g) : "Cannot add HMF components from different spaces";


### PR DESCRIPTION
## What

Lands the variable-ordering fix from #505 as a focused, standalone PR (cherry-pick of `70bc59e`, Eran's authorship preserved), separated from the CI / data / WIP changes bundled there.

`ConstructWeightedPolynomialRing` and `EvaluateMonomials` iterated an associative array in arbitrary order, so the weighted polynomial ring's variable order could disagree with the generator list and produce schemes with the wrong variable order. Both now iterate `Sort(Setseq(Keys(Gens)))`, giving a deterministic, matching order. `MakeScheme` gains a self-check (`assert &+[coeffs[i]*evaluated_mons[i]] eq 0`) that verifies each relation actually vanishes on the generators, supported by a new `eq(ModFrmHilDEltComp, RngElt)` intrinsic.

## Test

`Tests/graded_ring.m` (including `HilbertModularVariety` on Q(sqrt 13), which exercises `MakeScheme`) and `Tests/canonicalring_Qsqrt5.m` pass on top of current master.

## Notes

- Extracted from #505. The CI change from #505 is already on master via the separate CI PR (with additional hardening), and the broken `Mestre/Qsqrt3.m` and the unverified `2.2.5.1-31.2` data file are intentionally excluded.
