### PR TITLE
fix(canonical-ring): guard MakeScheme ordering check against zero relations

### DIFF
--- a/ModFrmHilD/CanonicalRing/CanonicalRing.m
+++ b/ModFrmHilD/CanonicalRing/CanonicalRing.m
@@ -578,8 +578,12 @@ intrinsic MakeScheme(Gens::Assoc, Relations::Assoc)-> Any
     // This is in order to verify we did not mess up the ordering.
     for rel in rels do
       coeffs, mons := CoefficientsAndMonomials(rel);
-      evaluated_mons := EvaluateMonomials(Gens, mons);
-      assert &+[coeffs[i]*evaluated_mons[i] : i in [1..#coeffs]] eq 0;
+      // A zero relation polynomial gives empty coeffs/mons, for which &+[] is
+      // illegal; such a relation is trivially satisfied, so skip the check.
+      if #coeffs gt 0 then
+        evaluated_mons := EvaluateMonomials(Gens, mons);
+        assert &+[coeffs[i]*evaluated_mons[i] : i in [1..#coeffs]] eq 0;
+      end if;
     end for;
     PolynomialList cat:= rels;
   end for;

--- a/Tests/canonical_ring_makescheme_zero_relation.m
+++ b/Tests/canonical_ring_makescheme_zero_relation.m
@@ -1,0 +1,21 @@
+// Regression: MakeScheme's relation-ordering self-check must not crash on a
+// zero relation polynomial. A zero relation yields empty coeffs/mons, so the
+// check `assert &+[...] eq 0` reduced an empty sequence (`&+[]`), which is
+// illegal in Magma. Such a relation is trivially satisfied and must be skipped.
+//
+// For a zero relation the monomial list is empty, so EvaluateMonomials never
+// touches the generators; placeholder generators suffice to drive the public
+// MakeScheme path that hits the bug.
+
+Gens := AssociativeArray();
+Gens[1] := [1, 2];   // two weight-1 generators; only the count/shape is used here
+
+R := ConstructWeightedPolynomialRing(Gens);              // Q[x1, x2], both weight 1
+nmons2 := #MonomialsOfWeightedDegree(R, 2);              // weight-2 monomials: x1^2, x1*x2, x2^2
+
+Relations := AssociativeArray();
+Relations[2] := [[Rationals() | 0 : j in [1..nmons2]]];  // a single all-zero (zero) relation
+
+// On the buggy code this errors at `&+[]`; with the fix it returns the scheme.
+S := MakeScheme(Gens, Relations);
+assert ISA(Type(S), Sch);


### PR DESCRIPTION
## What

Fixes a crash in `MakeScheme` (`ModFrmHilD/CanonicalRing/CanonicalRing.m`). The relation-ordering self-check reduces an empty sequence with `&+[]` when a relation polynomial is zero, which is illegal in Magma: a zero relation gives empty `coeffs`/`mons` from `CoefficientsAndMonomials`, so `&+[coeffs[i]*... : i in [1..0]]` is `&+[]` and raises `Runtime error in '&+': Illegal null sequence`.

A zero relation is trivially satisfied, so the fix skips the check when there are no coefficients.

## Test

`Tests/canonical_ring_makescheme_zero_relation.m` drives `MakeScheme` with a single all-zero relation. It errors on the base (`Illegal null sequence`) and passes with the fix. Regression: `graded_ring.m` (the real `MakeScheme` path, including `HilbertModularVariety` on Q(sqrt 13)) still passes.

## Notes

- The `MakeScheme` self-check was introduced with the recent variable-ordering fix; this hardens it against degenerate (zero) relations.
