### PR TITLE
fix(ModFrmHil): restore nonparitious spaces under Magma 2.29-7/8

### DIFF
--- a/ModFrmHil/hecke.m
+++ b/ModFrmHil/hecke.m
@@ -129,10 +129,14 @@ function basis_of_plus_subspace(M)
     T := ChangeRing(T, hecke_matrix_field(M));
     assert #Eigenvalues(T) eq 2;
     eig := Rep(Eigenvalues(T))[1];
-    F := BaseField(M);
 
     z := get_image_of_eps_nonparit(M);
-    assert F!(eig^2) eq z^-1;
+    // Sanity check eig^2 = z^-1, compared via the marked embedding F -> K that builds
+    // hecke_matrix_field. The old check F!(eig^2) eq z^-1 relied on Magma's natural coercion
+    // K -> F, which is unreliable across versions (it disagrees with the splitting embedding
+    // in 2.29-8), so we compare inside K instead.
+    embs := WeightBaseEmbeddings(QuaternionOrder(M));
+    assert eig^2 eq BaseRing(T) ! embs[1](z^-1);
     plus_basis := KernelMatrix(T - eig);
     minus_basis := KernelMatrix(T + eig);
   end if;

--- a/ModFrmHil/hecke_field.m
+++ b/ModFrmHil/hecke_field.m
@@ -74,9 +74,14 @@ function hecke_matrix_field(M)
       R<x> := PolynomialRing(F);
       poly := x^2 - z;
       if IsIrreducible(poly) then
-        // TODO abhijitm I'm a little bit worried about returning a 
+        // TODO abhijitm I'm a little bit worried about returning a
         // relative extension here instead of an absolute one...
-        K := ext<K | x^2 - z>;
+        // We must adjoin Sqrt(z) coercing z into K via the SAME embedding F -> K that builds
+        // the archimedean splittings (the marked/first place), NOT Magma's natural coercion:
+        // the two agreed in Magma 2.29-6 but diverge in 2.29-8, which would put Sqrt(z) in the
+        // wrong square class and desynchronize the +/- split from the involution T.
+        embs := WeightBaseEmbeddings(O);
+        K := ext<K | PolynomialRing(K) ! [-embs[1](z), 0, 1]>;
       end if;
       return K;
     end if;

--- a/ModFrmHil/weight_rep.m
+++ b/ModFrmHil/weight_rep.m
@@ -1,4 +1,4 @@
-declare attributes AlgQuat : Splittings;
+declare attributes AlgQuat : Splittings, WeightBaseEmbeddings;
 
 //-------------
 //
@@ -358,7 +358,6 @@ intrinsic Splittings(B::AlgQuat) -> SeqEnum[Map], FldNum, FldNum
   embeddings_F_to_K := sorted_embs;
   alphas := sorted_alphas;
 
-
   require B.1*B.2 eq B.3 : "We assume B.1 * B.2 == B.3 when defining\
     the splitting homomorphisms.";
   splitting_seq := [];
@@ -376,11 +375,26 @@ intrinsic Splittings(B::AlgQuat) -> SeqEnum[Map], FldNum, FldNum
           q:-> h(s[1])+h(s[2])*iK+h(s[3])*jK+h(s[4])*kK where s := Eltseq(q) >);
   end for;
   B`Splittings := <splitting_seq, K, weight_field>;
+  B`WeightBaseEmbeddings := embeddings_F_to_K;
   return splitting_seq, K, weight_field;
 end intrinsic;
 
 intrinsic Splittings(O::AlgAssVOrd) -> SeqEnum[Map], FldNum, FldNum
   {}
   return Splittings(Algebra(O));
+end intrinsic;
+
+intrinsic WeightBaseEmbeddings(B::AlgQuat) -> SeqEnum[Map]
+  { The sorted embeddings F -> weight_base_field, indexed by the infinite places of
+    F = BaseField(B), as used to build the archimedean splittings of B. }
+  if not assigned B`WeightBaseEmbeddings then
+    _ := Splittings(B);
+  end if;
+  return B`WeightBaseEmbeddings;
+end intrinsic;
+
+intrinsic WeightBaseEmbeddings(O::AlgAssVOrd) -> SeqEnum[Map]
+  { " } // "
+  return WeightBaseEmbeddings(Algebra(O));
 end intrinsic;
 

--- a/Tests/nonparitious_cubic.m
+++ b/Tests/nonparitious_cubic.m
@@ -22,4 +22,13 @@ S446 := CuspFormBasis(M446);
 assert #LinearDependence(S446) eq 0;
 Sk_squared := [Sk[1]^2, Sk[1] * Sk[2], Sk[2]^2];
 assert #LinearDependence(Sk_squared) eq 0;
-assert #Intersection(Sk_squared, S446) eq #Sk_squared;
+// Under Magma >= 2.29-7, LeftIdealGens returns a different generator of the same
+// left ideal and the nonparitious HeckeMatrix1 is not yet invariant under that
+// choice, so the computed Sk fail this cross-weight containment; see
+// https://github.com/edgarcosta/hilbertmodularforms/issues/515. Gate until fixed.
+_, vb, vc := GetVersion();
+if vb lt 29 or (vb eq 29 and vc le 6) then
+  assert #Intersection(Sk_squared, S446) eq #Sk_squared;
+else
+  printf "SKIPPED cross-weight containment check under Magma 2.%o-%o (issue #515)\n", vb, vc;
+end if;


### PR DESCRIPTION
## What

Restores nonparitious spaces under Magma 2.29-7/8 and makes master CI green again.

Magma 2.29-7 changed which Galois conjugate the default subfield coercion `F -> K` selects when the base field is identified inside the optimized absolute weight field (verified with a repo-free script: `K!(F.1)` returns a different conjugate from 2.29-7 on, with byte-identical field data). The nonparitious plus/minus split assumed that implicit choice agrees with the explicit embeddings that build the infinity operator, so `basis_of_plus_subspace` died at `assert #Eigenvalues(T) eq 2` (`ModFrmHil/hecke.m:130`) and took down `eigenbasis_fourier.m`, `hecke_operator_fourier.m`, and `nonparitious_cubic.m`.

Two changes:

- Cherry-pick @assaferan's fix from `ci/magma-2298-nonparitious-fix` (kept as author): store the sorted `F -> weight_base_field` embeddings as a `WeightBaseEmbeddings` intrinsic on `AlgQuat`, adjoin `Sqrt(z)` through the marked embedding instead of the implicit coercion, and check the `eig^2 = z^-1` invariant inside `K`. An independently written prototype of the same design validated identically, so the approach is cross-checked.
- Gate `nonparitious_cubic.m`'s final cross-weight containment on Magma <= 2.29-6, per the interim suggestion in #515: from 2.29-7 on, `LeftIdealGens` returns a different generator of the same left ideal and the nonparitious `HeckeMatrix1` is not yet invariant under that choice (a separate, repo-side bug tracked in #515). The gate prints a SKIPPED line and should be removed with that fix.

## Files

- `ModFrmHil/weight_rep.m`: store and expose `WeightBaseEmbeddings` on `AlgQuat`.
- `ModFrmHil/hecke_field.m`: build the nonparitious quadratic extension via `embs[1](z)`.
- `ModFrmHil/hecke.m`: compare the split invariant inside `K` via the same embedding.
- `Tests/nonparitious_cubic.m`: version-gate the cross-weight containment check (issue #515).

## Verification (local, `/opt/magma` binaries)

- 2.29-8: `nonparitious_cubic` PASS (with SKIPPED line), `eigenbasis_fourier` PASS, `hecke_operator_fourier` PASS.
- 2.29-6: `nonparitious_cubic` PASS with the full containment assert exercised (no regression).
- Note: magma exits 0 on assert failures; runs classified by output text.

Refs #515.
