### PR TITLE
fix(hz-divisors): repair find_mu CRT for ramified p=2 in other_primes

### DIFF
--- a/ModFrmHilD/HZDivisors.m
+++ b/ModFrmHilD/HZDivisors.m
@@ -169,21 +169,22 @@ function find_mu(theta, eta, a, D, bb, N)
     ideals cat:= [PrimeIdealsOverPrime(F,p)[1]^Valuation(D,p) : p in R1_primes];
     values cat:= [0 : p in R2_primes];
     ideals cat:= [p^Valuation(D,p)*ZF : p in R2_primes];
-    // TODO: Figure out what happens for p = 2 in other_primes !!
     for p in other_primes do
 	frakp := PrimeIdealsOverPrime(F,p)[1];
 	vD := Valuation(D,p);
-	vN, N0 := Valuation(N,p);
-	v := vD - vN;
-	pi := UniformizingElement(frakp);
-	if v eq 0 then
-	    elt := 0;
-	else
-	    ZFmodpv, red := quo<ZF | frakp^v>;
-	    elt := Sqrt(red(N0*Norm(bb)))@@red;
-	end if;
-	ZFmodpvD, redvD := quo<ZF | frakp^vD>;
-	Append(~values, redvD(pi^vN*elt));
+	ZFmodpvD := quo<ZF | frakp^vD>;
+	// The obvious closed form (pi^vN * sqrt(N0*Norm(bb)) mod frakp^(vD-vN))
+	// is unsound here: Norm(pi) is only p up to a unit that depends on the
+	// chosen uniformizer, so it drops a correction term. Since frakp is
+	// ramified, ZFmodpvD has only Norm(frakp)^vD = p^vD elements (p=2 is
+	// the only prime that reaches this branch with vD > vN, so this is at
+	// most 8 elements), so search it directly for a value with the right
+	// norm instead of re-deriving the closed form. Only the norm
+	// congruence matters: other_primes carry no theta/eta invariant, so
+	// any mu matching it here CRTs into a valid global mu.
+	found := exists(w){w : w in ZFmodpvD | (Norm(ZF!w) - N*Norm(bb)) mod p^vD eq 0};
+	assert found;
+	Append(~values, w);
 	Append(~ideals, frakp^vD);
     end for;
     for p in a_primes do

--- a/Tests/HZDivisors.m
+++ b/Tests/HZDivisors.m
@@ -125,6 +125,18 @@ end for;
 // Print newline.
 print "";
 
+// Deterministic case with a component ideal bb of large norm, for a field
+// where 2 is ramified with valuation 3 in the discriminant (D = 88 = 8*11).
+// This exercises find_mu's CRT construction at a prime dividing D that
+// divides N to a positive valuation strictly less than its valuation in D
+// (2 || N=2 but 2^3 || D=88), which the random draws above only cover
+// probabilistically.
+F88 := QuadraticField(88);
+ZF88 := Integers(F88);
+bb88 := ideal<ZF88 | 176*ZF88.2 - 1>;
+assert Norm(bb88) eq 681471;
+testHZDivisors(CongruenceSubgroup("SL", "Gamma0", F88, 1*ZF88, bb88));
+
 
 /* long test
 


### PR DESCRIPTION
## Summary

`Tests/HZDivisors.m` samples random `(d, b)` draws with no fixed seed, and intermittently trips `assert ((Norm(mu) - N*Norm(bb)) mod (a*D*Norm(bb))) eq 0` in `find_mu` (`ModFrmHilD/HZDivisors.m`). This isn't CI flakiness: it's a real bug in `find_mu`'s `other_primes` CRT construction, matching the file's own unresolved `// TODO: Figure out what happens for p = 2 in other_primes !!`. The closed form `pi^vN * sqrt(N0*Norm(bb))` used there drops a unit-correction term (`Norm(pi)` is only `p` up to a unit that depends on the chosen uniformizer). This branch is a no-op for every odd prime dividing `D` (`v_p(D)` is always 1, forcing `v=0`), so only `p=2` with `v_2(D) in {2,3}` ever exercised it — it fails whenever `D = 8 mod 16` and `N = 2`, for roughly a third of narrow class group representatives.

- `ModFrmHilD/HZDivisors.m`: replace the unsound closed form with a direct search over `ZF/frakp^vD` (at most 8 elements, since p=2 is the only prime reaching this branch) for a residue matching the required norm congruence.
- `Tests/HZDivisors.m`: add a deterministic case (D=88, a hardcoded ideal known to trigger the bug pre-fix) alongside the existing randomized coverage.

## Test plan

- [x] Scanned 3000 `SetSeed`'d draws of the existing random test: 103/3000 failed pre-fix (all `N=2`, `other_primes=[2]`, `D = 8 mod 16`), 0/3000 post-fix.
- [x] Red/green: the new deterministic D=88 case fails on the pre-fix code (`git stash`) and passes on the fix.
- [x] `Tests/HZDivisors.m` and `Tests/HZCuspIntersection.m` (the only other consumer of `GetAllHZComponents`) run clean repeatedly with fresh random draws.

Fixes #518
