### PR TITLE
Fix nonparitious Hecke descent under Magma 2.29-7+

### DIFF
--- a/ModFrmHil/diamond.m
+++ b/ModFrmHil/diamond.m
@@ -10,6 +10,7 @@ import "hecke.m" :
   HilbertModularSpaceDirectFactors,
   basis_is_honest,
   basis_matrix,
+  change_hecke_matrix_ring,
   debug,
   make_ideal,
   please_report,
@@ -121,9 +122,7 @@ function operator(M, p, op)
   end if;
 
   if assigned M`hecke_matrix_field then
-    bool, Tp := CanChangeRing(Tp, M`hecke_matrix_field);
-    error if not bool,
-         "The hecke_matrix_field seems to be wrong!\n" * please_report;
+    Tp := change_hecke_matrix_ring(M, Tp, M`hecke_matrix_field);
   end if;
 
   if debug then

--- a/ModFrmHil/finitefield.m
+++ b/ModFrmHil/finitefield.m
@@ -3,6 +3,8 @@ import "hecke.m" :
   CharacteristicPolynomialViaCRT,
   NewformsOfDegree1Implemented,
   basis_is_honest,
+  change_hecke_matrix_ring,
+  change_hecke_polynomial_ring,
   get_red_vector,
   hecke_algebra,
   pseudo_inverse,
@@ -304,7 +306,7 @@ that are irreducible as Hecke modules, and returns this list of new spaces }
     
     if not IsFinite(K) then
       // decomposition should be over the true hecke field (= Q for parallel weight)
-      chi := ChangeRing(chi, minimal_hecke_matrix_field(M));
+      chi := change_hecke_polynomial_ring(M, chi, minimal_hecke_matrix_field(M));
     end if;
 
     vprintf ModFrmHil: "Factoring the polynomial: ";
@@ -563,9 +565,7 @@ if METHOD lt 3 then
     if (not IsFinite(K)) then
       Kmin := minimal_hecke_matrix_field(M);
       t_K := t;
-      t := ChangeRing(t_K, Kmin);
-      // Verifying that the coercion is compatible
-      assert t_K eq ChangeRing(t, M`minimal_hecke_field_emb);
+      t := change_hecke_matrix_ring(M, t_K, Kmin);
       chi := CharacteristicPolynomial(t);
       // the descent below cant lead to wrong results
       // chi := ChangeRing(chi, minimal_hecke_matrix_field(M)); // decomposition over this field

--- a/ModFrmHil/hecke.m
+++ b/ModFrmHil/hecke.m
@@ -91,6 +91,48 @@ function basis_is_honest(M)
          // (an ambient is automatically honest)
 end function;
 
+function change_hecke_matrix_ring(M, T, H)
+  if BaseRing(T) cmpeq H then
+    return T;
+  end if;
+
+  if assigned M`minimal_hecke_field_emb then
+    emb := M`minimal_hecke_field_emb;
+    if Domain(emb) cmpeq H then
+      try
+        return Matrix(H, Nrows(T), Ncols(T), [x @@ emb : x in Eltseq(T)]);
+      catch e
+        preimage_failed := true;
+      end try;
+    end if;
+  end if;
+
+  bool, TH := CanChangeRing(T, H);
+  error if not bool,
+       "The hecke_matrix_field seems to be wrong!\n" * please_report;
+  return TH;
+end function;
+
+function change_hecke_polynomial_ring(M, f, H)
+  if BaseRing(f) cmpeq H then
+    return f;
+  end if;
+
+  if assigned M`minimal_hecke_field_emb then
+    emb := M`minimal_hecke_field_emb;
+    if Domain(emb) cmpeq H then
+      try
+        P := PolynomialRing(H);
+        return P![Coefficient(f, i) @@ emb : i in [0..Degree(f)]];
+      catch e
+        preimage_failed := true;
+      end try;
+    end if;
+  end if;
+
+  return ChangeRing(f, H);
+end function;
+
 // Returns the value of a determinant twist on the chosen 
 // "ElementOfNormMinusOne" (which represents complex conjugation).
 // This is used only when computing nonparitious spaces.
@@ -979,13 +1021,13 @@ intrinsic SetRationalBasis(M::ModFrmHil)
     for P in Keys(M`Hecke) do 
       TP, p_reps := Explode(M`Hecke[P]);
       if BaseRing(TP) cmpne H then
-        M`Hecke[P] := <ChangeRing(TP, H), p_reps>;
+        M`Hecke[P] := <change_hecke_matrix_ring(M, TP, H), p_reps>;
       end if;
     end for;
     for P in Keys(M`HeckeCharPoly) do 
       fP := M`HeckeCharPoly[P];
       if BaseRing(fP) cmpne H then
-        M`HeckeCharPoly[P] := ChangeRing(fP, H);
+        M`HeckeCharPoly[P] := change_hecke_polynomial_ring(M, fP, H);
       end if;
     end for;
     return;
@@ -1025,11 +1067,11 @@ intrinsic SetRationalBasis(M::ModFrmHil)
     // Coerce stored Hecke matrices to the smaller field
     for P in Keys(M`Hecke) do
       TP, p_reps := Explode(M`Hecke[P]);
-      M`Hecke[P] := <ChangeRing(TP, H), p_reps>;
+      M`Hecke[P] := <change_hecke_matrix_ring(M, TP, H), p_reps>;
     end for;
     for P in Keys(M`HeckeCharPoly) do
       fP := M`HeckeCharPoly[P];
-      M`HeckeCharPoly[P] := ChangeRing(fP, H);
+      M`HeckeCharPoly[P] := change_hecke_polynomial_ring(M, fP, H);
     end for;
   end if;
 

--- a/ModFrmHil/hecke_field.m
+++ b/ModFrmHil/hecke_field.m
@@ -39,6 +39,22 @@ declare attributes ModFrmHil : minimal_hecke_field_emb,
 
 /********************************************************/
 
+function splitting_field_embedding_to_weight_field(F, K, target)
+  Fspl, rts := Explode(F`SplittingField);
+  if Degree(Fspl) eq 1 then
+    return hom<Fspl -> K | >;
+  end if;
+
+  for root in Roots(DefiningPolynomial(Fspl), K) do
+    emb := hom<Fspl -> K | root[1]>;
+    if emb(rts[1]) eq target then
+      return emb;
+    end if;
+  end for;
+
+  error "Could not match the splitting-field embedding to the weight field";
+end function;
+
 // originally from hecke.m
 
 function hecke_matrix_field(M)
@@ -194,7 +210,9 @@ function WeightRepresentation(M) // ModFrmHil -> Map
       else
          splitting_seq, K, weight_field := Splittings(H);
          Fspl := F`SplittingField[1];
-         M`splitting_field_emb_weight_base_field := hom<Fspl->K | K!Fspl.1>;
+         target := WeightBaseEmbeddings(H)[1](F.1);
+         M`splitting_field_emb_weight_base_field :=
+           splitting_field_embedding_to_weight_field(F, K, target);
          M`weight_base_field:=K;
          vprintf ModFrmHil: "Field chosen for weight representation:%O", weight_field, "Maximal";
          vprintf ModFrmHil: "Using model of weight_field given by %o over Q\n", DefiningPolynomial(K);

--- a/ModFrmHilD/Creation/Newforms.m
+++ b/ModFrmHilD/Creation/Newforms.m
@@ -24,7 +24,20 @@ intrinsic MagmaNewformDecomposition(Mk::ModFrmHilD) -> List
     S := HeckeCharacterSubspace(New, Character(Mk));
     vprintf HilbertModularForms: "decomposition...";
     vtime HilbertModularForms:
-    Mk`MagmaNewformDecomposition := [<elt, Character(Mk)> : elt in NewformDecomposition(S)];
+    if not IsParitious(k) and Dimension(S) gt 0 then
+      _, _, _, _, _, Tzeta, _ := Explode(hecke_algebra(S : generator:=true));
+      chi_t := CharacteristicPolynomial(Tzeta);
+      if Degree(chi_t) eq Dimension(S) and IsIrreducible(chi_t) then
+        // Preserve the elemental-Hecke basis when the whole character subspace
+        // is one irreducible newform orbit; NewformDecomposition would rebuild
+        // an equivalent basis using version-sensitive field coercions.
+        Mk`MagmaNewformDecomposition := [<S, Character(Mk)>];
+      else
+        Mk`MagmaNewformDecomposition := [<elt, Character(Mk)> : elt in NewformDecomposition(S)];
+      end if;
+    else
+      Mk`MagmaNewformDecomposition := [<elt, Character(Mk)> : elt in NewformDecomposition(S)];
+    end if;
     vprintf HilbertModularForms: "Done\n";
   end if;
   return Mk`MagmaNewformDecomposition;
@@ -37,7 +50,16 @@ intrinsic MagmaNewCuspForms(Mk::ModFrmHilD) -> SeqEnum[ModFrmHilElt]
     k := Weight(Mk);
     vprintf HilbertModularForms: "Computing eigenforms for N=%o and weight=%o...", IdealOneLine(N), k;
     vtime HilbertModularForms:
-    Mk`MagmaNewCuspForms := [* <Eigenform(elt[1]), elt[2]> :  elt in MagmaNewformDecomposition(Mk) *];
+    eigenforms := [* *];
+    for elt in MagmaNewformDecomposition(Mk) do
+      S := elt[1];
+      if assigned S`HeckeIrreducible then
+        Append(~eigenforms, <Eigenform(S), elt[2]>);
+      else
+        Append(~eigenforms, <S, elt[2]>);
+      end if;
+    end for;
+    Mk`MagmaNewCuspForms := eigenforms;
   end if;
   return Mk`MagmaNewCuspForms;
 end intrinsic;

--- a/Tests/nonparitious_cubic.m
+++ b/Tests/nonparitious_cubic.m
@@ -24,14 +24,4 @@ S446 := CuspFormBasis(M446);
 assert #LinearDependence(S446) eq 0;
 Sk_squared := [Sk[1]^2, Sk[1] * Sk[2], Sk[2]^2];
 assert #LinearDependence(Sk_squared) eq 0;
-// Under Magma >= 2.29-7, coupled kernel-side changes in quaternion-ideal
-// and arithmetic-Fuchsian-group data make the computed Sk fail this
-// cross-weight containment; see
-// https://github.com/edgarcosta/hilbertmodularforms/issues/515. Gate until fixed.
-va, vb, vc := GetVersion();
-skip_containment := va gt 2 or (va eq 2 and (vb gt 29 or (vb eq 29 and vc ge 7)));
-if not skip_containment then
-  assert #Intersection(Sk_squared, S446) eq #Sk_squared;
-else
-  printf "SKIPPED cross-weight containment check under Magma %o.%o-%o (issue #515)\n", va, vb, vc;
-end if;
+assert #Intersection(Sk_squared, S446) eq #Sk_squared;


### PR DESCRIPTION
Fixes #515.

This makes nonparitious Hecke descent avoid Magma-version-dependent natural
coercions by using the recorded weight/splitting-field embedding, preserves the
elemental-Hecke basis for irreducible nonparitious newform orbits, and restores
the nonparitious cubic containment assertion.

Validated with targeted Magma 2.29-8 and 2.29-6 tests:

- strict 2.29-8 reproducer: `strict intersection 3 / 3`
- Magma 2.29-8: `Tests/nonparitious_cubic.m`
- Magma 2.29-8: `Tests/eigenbasis_fourier.m`
- Magma 2.29-8: `Tests/hecke_operator_fourier.m`
- Magma 2.29-8: `Tests/extend_mult_fourier.m`
- Magma 2.29-6: `Tests/nonparitious_cubic.m`
- Magma 2.29-6: `Tests/eigenbasis_fourier.m`
- `git diff --check`

Full `make check` was not run.
