### PR TITLE
chore: gitignore local work files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ ModFrmHil/spec~
 *.ipynb
 ModFrmHilD/vdgV.m
 *.html
+Mestre/MestreConic12.m
+Mestre/MestreCubic12.m.txt
+WorkInProgress/X0p31_Qsqrt5.pdf


### PR DESCRIPTION
Ignore untracked scratch artifacts (Mestre conic/cubic scripts and the X0p31_Qsqrt5 writeup PDF) so they stop showing up as untracked.